### PR TITLE
Cache multithreading bugfix

### DIFF
--- a/lotus/cache.py
+++ b/lotus/cache.py
@@ -114,92 +114,101 @@ class CacheFactory:
     def create_default_cache(max_size: int = 1024) -> Cache:
         return CacheFactory.create_cache(CacheConfig(CacheType.IN_MEMORY, max_size))
 
+class ThreadLocalConnection:
+    """Wrapper that automatically closes connection when thread dies"""
+    def __init__(self, db_path: str):
+        self._db_path = db_path
+        self._conn = None
+    
+    @property
+    def connection(self) -> sqlite3.Connection:
+        if self._conn is None:
+            self._conn = sqlite3.connect(self._db_path)
+        return self._conn
+    
+    def __del__(self):
+        if self._conn is not None:
+            self._conn.close()
 
 class SQLiteCache(Cache):
     def __init__(self, max_size: int, cache_dir=os.path.expanduser("~/.lotus/cache")):
         super().__init__(max_size)
         self.db_path = os.path.join(cache_dir, "lotus_cache.db")
         os.makedirs(os.path.dirname(self.db_path), exist_ok=True)
-        self.conn = sqlite3.connect(self.db_path, check_same_thread=False)
-        self._lock = threading.Lock() 
+        self._local = threading.local()
         self._create_table()
-        
+    
+    def _get_connection(self) -> sqlite3.Connection:
+        if not hasattr(self._local, 'conn_wrapper'):
+            self._local.conn_wrapper = ThreadLocalConnection(self.db_path)
+        return self._local.conn_wrapper.connection
 
     def _create_table(self):
-        with self._lock:
-            with self.conn:
-                self.conn.execute("""
-                    CREATE TABLE IF NOT EXISTS cache (
-                        key TEXT PRIMARY KEY,
-                        value BLOB,
-                        last_accessed INTEGER
-                    )
-                """)
+        with self._get_connection() as conn:
+            conn.execute("""
+                CREATE TABLE IF NOT EXISTS cache (
+                    key TEXT PRIMARY KEY,
+                    value BLOB,
+                    last_accessed INTEGER
+                )
+            """)
 
     def _get_time(self):
         return int(time.time())
 
     @require_cache_enabled
     def get(self, key: str) -> Any | None:
-        with self._lock:
-            with self.conn:
-                cursor = self.conn.execute("SELECT value FROM cache WHERE key = ?", (key,))
-                result = cursor.fetchone()
-                if result:
-                    lotus.logger.debug(f"Cache hit for {key}")
-                    value = pickle.loads(result[0])
-                    self.conn.execute(
-                        "UPDATE cache SET last_accessed = ? WHERE key = ?",
-                        (
-                            self._get_time(),
-                            key,
-                        ),
-                    )
-                    return value
-                cursor.close()
-            return None
+        with self._get_connection() as conn:
+            cursor = conn.execute("SELECT value FROM cache WHERE key = ?", (key,))
+            result = cursor.fetchone()
+            if result:
+                lotus.logger.debug(f"Cache hit for {key}")
+                value = pickle.loads(result[0])
+                conn.execute(
+                    "UPDATE cache SET last_accessed = ? WHERE key = ?",
+                    (
+                        self._get_time(),
+                        key,
+                    ),
+                )
+                return value
+            cursor.close()
+        return None
 
     @require_cache_enabled
     def insert(self, key: str, value: Any):
         pickled_value = pickle.dumps(value)
-        with self._lock:
-            with self.conn:
-                self.conn.execute(
-                    """
-                    INSERT OR REPLACE INTO cache (key, value, last_accessed) 
-                    VALUES (?, ?, ?)
-                """,
-                    (key, pickled_value, self._get_time()),
-                )
-                self._enforce_size_limit()
+        with self._get_connection() as conn:
+            conn.execute(
+                """
+                INSERT OR REPLACE INTO cache (key, value, last_accessed) 
+                VALUES (?, ?, ?)
+            """,
+                (key, pickled_value, self._get_time()),
+            )
+            self._enforce_size_limit()
 
     def _enforce_size_limit(self):
-        with self._lock:
-            with self.conn:
-                count = self.conn.execute("SELECT COUNT(*) FROM cache").fetchone()[0]
-                if count > self.max_size:
-                    num_to_delete = count - self.max_size
-                    self.conn.execute(
-                        """
-                        DELETE FROM cache WHERE key IN (
-                            SELECT key FROM cache
-                            ORDER BY last_accessed ASC
-                            LIMIT ?
-                        )
-                    """,
-                        (num_to_delete,),
+        with self._get_connection() as conn:
+            count = conn.execute("SELECT COUNT(*) FROM cache").fetchone()[0]
+            if count > self.max_size:
+                num_to_delete = count - self.max_size
+                conn.execute(
+                    """
+                    DELETE FROM cache WHERE key IN (
+                        SELECT key FROM cache
+                        ORDER BY last_accessed ASC
+                        LIMIT ?
                     )
+                """,
+                    (num_to_delete,),
+                )
 
     def reset(self, max_size: int | None = None):
-        with self._lock:
-            with self.conn:
-                self.conn.execute("DELETE FROM cache")
-            if max_size is not None:
-                self.max_size = max_size
-
-    def __del__(self):
-        self.conn.close()
-
+        with self._get_connection() as conn:
+            conn.execute("DELETE FROM cache")
+        if max_size is not None:
+            self.max_size = max_size
 
 class InMemoryCache(Cache):
     def __init__(self, max_size: int):

--- a/lotus/cache.py
+++ b/lotus/cache.py
@@ -9,10 +9,12 @@ from collections import OrderedDict
 from enum import Enum
 from functools import wraps
 from typing import Any, Callable
+import threading
 
 import pandas as pd
 
 import lotus
+
 
 
 def require_cache_enabled(func: Callable) -> Callable:
@@ -118,74 +120,82 @@ class SQLiteCache(Cache):
         super().__init__(max_size)
         self.db_path = os.path.join(cache_dir, "lotus_cache.db")
         os.makedirs(os.path.dirname(self.db_path), exist_ok=True)
-        self.conn = sqlite3.connect(self.db_path)
+        self.conn = sqlite3.connect(self.db_path, check_same_thread=False)
+        self._lock = threading.Lock() 
         self._create_table()
+        
 
     def _create_table(self):
-        with self.conn:
-            self.conn.execute("""
-                CREATE TABLE IF NOT EXISTS cache (
-                    key TEXT PRIMARY KEY,
-                    value BLOB,
-                    last_accessed INTEGER
-                )
-            """)
+        with self._lock:
+            with self.conn:
+                self.conn.execute("""
+                    CREATE TABLE IF NOT EXISTS cache (
+                        key TEXT PRIMARY KEY,
+                        value BLOB,
+                        last_accessed INTEGER
+                    )
+                """)
 
     def _get_time(self):
         return int(time.time())
 
     @require_cache_enabled
     def get(self, key: str) -> Any | None:
-        with self.conn:
-            cursor = self.conn.execute("SELECT value FROM cache WHERE key = ?", (key,))
-            result = cursor.fetchone()
-            if result:
-                lotus.logger.debug(f"Cache hit for {key}")
-                value = pickle.loads(result[0])
-                self.conn.execute(
-                    "UPDATE cache SET last_accessed = ? WHERE key = ?",
-                    (
-                        self._get_time(),
-                        key,
-                    ),
-                )
-                return value
-        return None
+        with self._lock:
+            with self.conn:
+                cursor = self.conn.execute("SELECT value FROM cache WHERE key = ?", (key,))
+                result = cursor.fetchone()
+                if result:
+                    lotus.logger.debug(f"Cache hit for {key}")
+                    value = pickle.loads(result[0])
+                    self.conn.execute(
+                        "UPDATE cache SET last_accessed = ? WHERE key = ?",
+                        (
+                            self._get_time(),
+                            key,
+                        ),
+                    )
+                    return value
+                cursor.close()
+            return None
 
     @require_cache_enabled
     def insert(self, key: str, value: Any):
         pickled_value = pickle.dumps(value)
-        with self.conn:
-            self.conn.execute(
-                """
-                INSERT OR REPLACE INTO cache (key, value, last_accessed) 
-                VALUES (?, ?, ?)
-            """,
-                (key, pickled_value, self._get_time()),
-            )
-            self._enforce_size_limit()
-
-    def _enforce_size_limit(self):
-        with self.conn:
-            count = self.conn.execute("SELECT COUNT(*) FROM cache").fetchone()[0]
-            if count > self.max_size:
-                num_to_delete = count - self.max_size
+        with self._lock:
+            with self.conn:
                 self.conn.execute(
                     """
-                    DELETE FROM cache WHERE key IN (
-                        SELECT key FROM cache
-                        ORDER BY last_accessed ASC
-                        LIMIT ?
-                    )
+                    INSERT OR REPLACE INTO cache (key, value, last_accessed) 
+                    VALUES (?, ?, ?)
                 """,
-                    (num_to_delete,),
+                    (key, pickled_value, self._get_time()),
                 )
+                self._enforce_size_limit()
+
+    def _enforce_size_limit(self):
+        with self._lock:
+            with self.conn:
+                count = self.conn.execute("SELECT COUNT(*) FROM cache").fetchone()[0]
+                if count > self.max_size:
+                    num_to_delete = count - self.max_size
+                    self.conn.execute(
+                        """
+                        DELETE FROM cache WHERE key IN (
+                            SELECT key FROM cache
+                            ORDER BY last_accessed ASC
+                            LIMIT ?
+                        )
+                    """,
+                        (num_to_delete,),
+                    )
 
     def reset(self, max_size: int | None = None):
-        with self.conn:
-            self.conn.execute("DELETE FROM cache")
-        if max_size is not None:
-            self.max_size = max_size
+        with self._lock:
+            with self.conn:
+                self.conn.execute("DELETE FROM cache")
+            if max_size is not None:
+                self.max_size = max_size
 
     def __del__(self):
         self.conn.close()

--- a/lotus/cache.py
+++ b/lotus/cache.py
@@ -119,7 +119,7 @@ class ThreadLocalConnection:
 
     def __init__(self, db_path: str):
         self._db_path = db_path
-        self._conn = None
+        self._conn: sqlite3.Connection | None = None
 
     @property
     def connection(self) -> sqlite3.Connection:


### PR DESCRIPTION
Fixes the issue described in #88 by creating a new SQlite connection per thread and handles cleanup accoridingly by storing the connection in a Thread.Local() object.