### PR TITLE
Allow Mulit-Col Map Output

### DIFF
--- a/examples/op_examples/map_multi_col.py
+++ b/examples/op_examples/map_multi_col.py
@@ -1,0 +1,32 @@
+import logging
+
+import pandas as pd
+from pydantic import BaseModel
+
+import lotus
+from lotus.models import LM
+
+lm = LM(model="gpt-4o-mini")
+
+lotus.settings.configure(lm=lm)
+data = {
+    "Course Name": [
+        "Probability and Random Processes",
+        "Optimization Methods in Engineering",
+        "Digital Design and Integrated Circuits",
+        "Computer Security",
+    ]
+}
+df = pd.DataFrame(data)
+user_instruction = (
+    "What is a similar course to {Course Name}. Also give a study plan for the similar course. Be concise."
+)
+
+
+class Course(BaseModel):
+    new_course_name: str
+    new_course_study_plan: str
+
+
+df = df.sem_map(user_instruction, response_format=Course)
+print(df)

--- a/lotus/sem_ops/postprocessors.py
+++ b/lotus/sem_ops/postprocessors.py
@@ -1,5 +1,7 @@
 import json
 
+from pydantic import BaseModel
+
 import lotus
 from lotus.types import (
     SemanticExtractPostprocessOutput,
@@ -37,7 +39,9 @@ def map_postprocess_cot(llm_answers: list[str]) -> SemanticMapPostprocessOutput:
     return SemanticMapPostprocessOutput(raw_outputs=llm_answers, outputs=outputs, explanations=explanations)
 
 
-def map_postprocess(llm_answers: list[str], cot_reasoning: bool = False) -> SemanticMapPostprocessOutput:
+def map_postprocess(
+    llm_answers: list[str], response_format: type[BaseModel], cot_reasoning: bool = False
+) -> SemanticMapPostprocessOutput:
     """
     Postprocess the output of the map operator.
 
@@ -51,7 +55,9 @@ def map_postprocess(llm_answers: list[str], cot_reasoning: bool = False) -> Sema
     if cot_reasoning:
         return map_postprocess_cot(llm_answers)
 
-    outputs: list[str] = llm_answers
+    outputs: list[dict[str, str]] = [
+        response_format.model_validate_json(llm_answer).model_dump() for llm_answer in llm_answers
+    ]
     explanations: list[str | None] = [None] * len(llm_answers)
     return SemanticMapPostprocessOutput(raw_outputs=llm_answers, outputs=outputs, explanations=explanations)
 

--- a/lotus/types.py
+++ b/lotus/types.py
@@ -49,14 +49,14 @@ class LogprobsForFilterCascade:
 @dataclass
 class SemanticMapPostprocessOutput:
     raw_outputs: list[str]
-    outputs: list[str]
+    outputs: list[dict[str, str]]
     explanations: list[str | None]
 
 
 @dataclass
 class SemanticMapOutput:
     raw_outputs: list[str]
-    outputs: list[str]
+    outputs: list[dict[str, str]]
     explanations: list[str | None]
 
 


### PR DESCRIPTION
Lets users specify a `pydantic` model for output schema specification on `sem_map`. If no user schema is provided then a defualt schema of `map_output` is used.