### PR TITLE
Return LM Filter Probabilities

### DIFF
--- a/examples/op_examples/filter_cascade.py
+++ b/examples/op_examples/filter_cascade.py
@@ -3,12 +3,14 @@ import pandas as pd
 import lotus
 from lotus.models import LM, LiteLLMRM
 from lotus.types import CascadeArgs, ProxyModel
+from lotus.vector_store import FaissVS
 
 gpt_4o_mini = LM("gpt-4o-mini")
 gpt_4o = LM("gpt-4o")
 rm = LiteLLMRM(model="text-embedding-3-small")
+vs = FaissVS()
 
-lotus.settings.configure(lm=gpt_4o, helper_lm=gpt_4o_mini, rm=rm)
+lotus.settings.configure(lm=gpt_4o, helper_lm=gpt_4o_mini, rm=rm, vs=vs)
 data = {
     "Course Name": [
         "Probability and Random Processes",

--- a/lotus/models/lm.py
+++ b/lotus/models/lm.py
@@ -178,6 +178,7 @@ class LM:
             if "True" in token_probs and "False" in token_probs:
                 true_prob = token_probs["True"]
                 false_prob = token_probs["False"]
+                print(f"True probability: {true_prob}, False probability: {false_prob}")
                 return true_prob / (true_prob + false_prob)
             return None
 

--- a/lotus/models/lm.py
+++ b/lotus/models/lm.py
@@ -172,28 +172,40 @@ class LM:
     ) -> LogprobsForFilterCascade:
         # Get base cascade format first
         base_cascade = self.format_logprobs_for_cascade(logprobs)
-        all_true_probs = []
+        all_true_probs: list[float] = []
 
         def get_normalized_true_prob(token_probs: dict[str, float]) -> float | None:
-            if "True" in token_probs and "False" in token_probs:
-                true_prob = token_probs["True"]
-                false_prob = token_probs["False"]
-                print(f"True probability: {true_prob}, False probability: {false_prob}")
+            # Normalize keys by converting to lowercase and stripping whitespace
+            # Take the max probability for each key (e.g. True and true both map to "true" so we take the max of the two)
+            normalized_probs: dict[str, float] = {}
+            for k, v in token_probs.items():
+                normalized_key = k.lower().strip()
+                normalized_probs[normalized_key] = max(v, normalized_probs.get(normalized_key, float("-inf")))
+
+            # Look for true/false in normalized keys
+            if "true" in normalized_probs and "false" in normalized_probs:
+                true_prob = normalized_probs["true"]
+                false_prob = normalized_probs["false"]
                 return true_prob / (true_prob + false_prob)
             return None
 
-        # Get true probabilities for filter cascade
-        for resp_idx, response_logprobs in enumerate(logprobs):
-            true_prob = None
-            for logprob in response_logprobs:
-                token_probs = {top.token: np.exp(top.logprob) for top in logprob.top_logprobs}
-                true_prob = get_normalized_true_prob(token_probs)
-                if true_prob is not None:
-                    break
+        for response_logprobs in logprobs:
+            true_prob: float = 1  # Default if no true/false token found
 
-            # Default to 1 if "True" in tokens, 0 if not
-            if true_prob is None:
-                true_prob = 1 if "True" in base_cascade.tokens[resp_idx] else 0
+            for logprob in reversed(response_logprobs):
+                cleaned_token = logprob.token.lower().strip()
+                if cleaned_token not in ["true", "false"]:
+                    continue
+
+                token_probs = {top.token: np.exp(top.logprob) for top in logprob.top_logprobs}
+                normalized_prob = get_normalized_true_prob(token_probs)
+
+                # Fall back to binary true/false if normalization fails
+                if normalized_prob is None:
+                    true_prob = 1 if cleaned_token == "true" else 0
+                else:
+                    true_prob = normalized_prob
+                break
 
             all_true_probs.append(true_prob)
 

--- a/lotus/sem_ops/sem_filter.py
+++ b/lotus/sem_ops/sem_filter.py
@@ -162,6 +162,7 @@ class SemFilterDataframe:
         strategy: str | None = None,
         cascade_args: CascadeArgs | None = None,
         return_stats: bool = False,
+        return_probs: bool = False,
         safe_mode: bool = False,
         progress_bar_desc: str = "Filtering",
         additional_cot_instructions: str = "",
@@ -183,6 +184,7 @@ class SemFilterDataframe:
                 sampling_percentage (float): The percentage of the data to sample when cascading. Defaults to 0.1.
                 failure_probability (float): The failure probability when cascading. Defaults to 0.2.
             return_stats (bool): Whether to return statistics. Defaults to False.
+            return_probs (bool): Whether to return probabilities. Defaults to False.
             additional_cot_instructions (str): Additional instructions for the CoT. Defaults to "".
 
         Returns:
@@ -330,14 +332,11 @@ class SemFilterDataframe:
             outputs: list[bool] = [False] * len(multimodal_data)
             raw_outputs: list[str] = [""] * len(multimodal_data)
             explanations: list[str | None] = [None] * len(multimodal_data)
-
-            if return_stats:
-                stats["probs"] = [0.0] * len(multimodal_data)
+            probs: list[float] = [0.0] * len(multimodal_data)
 
             for idx in high_conf_idxs:
                 outputs[idx] = proxy_outputs[idx]
-                if return_stats:
-                    stats["probs"][idx] = proxy_scores[idx]
+                probs[idx] = proxy_scores[idx]
 
             # If using helper LM, get raw outputs and explanations
             if proxy_model == ProxyModel.HELPER_LM:
@@ -363,11 +362,12 @@ class SemFilterDataframe:
                     strategy=strategy,
                     safe_mode=safe_mode,
                     progress_bar_desc="Running predicate evals with oracle LM",
-                    logprobs=return_stats,
+                    logprobs=return_probs,
                     additional_cot_instructions=additional_cot_instructions,
                 )
 
-                if return_stats and large_output.logprobs:
+                if return_probs:
+                    assert large_output.logprobs is not None, "Logprobs must be returned if return_probs is True"
                     formatted_logprobs = lotus.settings.lm.format_logprobs_for_filter_cascade(large_output.logprobs)
                     large_probs = formatted_logprobs.true_probs
 
@@ -375,8 +375,8 @@ class SemFilterDataframe:
                     outputs[large_idx] = large_output.outputs[idx]
                     raw_outputs[large_idx] = large_output.raw_outputs[idx]
                     explanations[large_idx] = large_output.explanations[idx]
-                    if return_stats:
-                        stats["probs"][large_idx] = large_probs[idx]
+                    if return_probs:
+                        probs[large_idx] = large_probs[idx]
 
             stats["filters_resolved_by_helper_model"] += len(high_conf_idxs)
             stats["filters_resolved_by_large_model"] += len(low_conf_idxs)
@@ -394,17 +394,19 @@ class SemFilterDataframe:
                 safe_mode=safe_mode,
                 show_progress_bar=True,
                 progress_bar_desc=progress_bar_desc,
-                logprobs=return_stats,  # stats includes logprobs
+                logprobs=return_probs,
                 additional_cot_instructions=additional_cot_instructions,
             )
             outputs = output.outputs
             raw_outputs = output.raw_outputs
             explanations = output.explanations
 
-            if return_stats:
-                assert output.logprobs is not None, "logprobs must be returned to get stats"
+            if return_probs:
+                assert output.logprobs is not None, "Logprobs must be returned if return_probs is True"
                 formatted_logprobs = lotus.settings.lm.format_logprobs_for_filter_cascade(output.logprobs)
-                stats["probs"] = formatted_logprobs.true_probs
+                probs = formatted_logprobs.true_probs
+            else:
+                probs = [0.0] * len(multimodal_data)
 
         if not return_all:
             # find indices where output is True
@@ -416,6 +418,7 @@ class SemFilterDataframe:
             [outputs[i] for i in ids]
             filtered_explanations = [explanations[i] for i in ids]
             filtered_raw_outputs = [raw_outputs[i] for i in ids]
+            filtered_probs = [probs[i] for i in ids]
             lotus.logger.debug(f"filtered_raw_outputs: {filtered_raw_outputs}")
 
             new_df = self._obj.iloc[ids]
@@ -435,6 +438,7 @@ class SemFilterDataframe:
             new_df[get_out_col_name(new_df, "filter_label")] = outputs
             filtered_explanations = explanations
             filtered_raw_outputs = raw_outputs
+            filtered_probs = probs
 
         # return rows where output is True
         if return_explanations and return_raw_outputs:
@@ -444,6 +448,9 @@ class SemFilterDataframe:
             new_df["explanation" + suffix] = filtered_explanations
         elif return_raw_outputs:
             new_df["raw_output" + suffix] = filtered_raw_outputs
+
+        if return_probs:
+            new_df["probs" + suffix] = filtered_probs
 
         if return_stats:
             return new_df, stats

--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -108,7 +108,6 @@ class TestFilterWithProbs(BaseTest):
         """Test semantic filter with probabilities returned to the user"""
         lm = LM(model="gpt-4o-mini")
         lotus.settings.configure(lm=lm)
-        result, stats = sample_df.sem_filter("{Course Name} is useful for life", return_stats=True)
+        result = sample_df.sem_filter("{Course Name} will be fun", return_probs=True)
         print(result)
-        print(stats)
-        assert "probs" in stats
+        assert "probs_filter" in result.columns

--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -111,3 +111,17 @@ class TestFilterWithProbs(BaseTest):
         result = sample_df.sem_filter("{Course Name} will be fun", return_probs=True)
         print(result)
         assert "probs_filter" in result.columns
+
+    def test_filter_with_probs_and_return_all(self, sample_df):
+        """Test semantic filter with probabilities returned to the user"""
+        lm = LM(model="gpt-4o-mini")
+        lotus.settings.configure(lm=lm)
+        result = sample_df.sem_filter("{Course Name} will be fun", return_probs=True, return_all=True)
+        print(result)
+        assert "probs_filter" in result.columns
+
+        for idx, row in result.iterrows():
+            if row["filter_label"]:
+                assert row["probs_filter"] > 0.5
+            else:
+                assert row["probs_filter"] <= 0.5

--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -1,31 +1,29 @@
 import pandas as pd
 import pytest
 
+import lotus
+from lotus.models import LM
 from tests.base_test import BaseTest
 
 
 @pytest.fixture
 def sample_df():
-    return pd.DataFrame({
-        "Course Name": [
-            "Introduction to Programming",
-            "Advanced Programming",
-            "Cooking Basics",
-            "Advanced Culinary Arts",
-            "Data Structures",
-            "Algorithms",
-            "French Cuisine",
-            "Italian Cooking"
-        ],
-        "Department": [
-            "CS", "CS", "Culinary", "Culinary",
-            "CS", "CS", "Culinary", "Culinary"
-        ],
-        "Level": [
-            100, 200, 100, 200,
-            300, 300, 200, 200
-        ]
-    })
+    return pd.DataFrame(
+        {
+            "Course Name": [
+                "Introduction to Programming",
+                "Advanced Programming",
+                "Cooking Basics",
+                "Advanced Culinary Arts",
+                "Data Structures",
+                "Algorithms",
+                "French Cuisine",
+                "Italian Cooking",
+            ],
+            "Department": ["CS", "CS", "Culinary", "Culinary", "CS", "CS", "Culinary", "Culinary"],
+            "Level": [100, 200, 100, 200, 300, 300, 200, 200],
+        }
+    )
 
 
 class TestSearch(BaseTest):
@@ -41,11 +39,11 @@ class TestSearch(BaseTest):
         """Test semantic search with relational filter"""
         # Index the dataframe
         df = sample_df.sem_index("Course Name", "course_index")
-        
+
         # Apply relational filter and search
         filtered_df = df[df["Department"] == "CS"]
         result = filtered_df.sem_search("Course Name", "advanced courses", K=2)
-        
+
         assert len(result) == 2
         # Should only return CS courses
         assert all(dept == "CS" for dept in result["Department"])
@@ -55,11 +53,11 @@ class TestSearch(BaseTest):
         """Test semantic search after semantic filter"""
         # Index the dataframe
         df = sample_df.sem_index("Course Name", "course_index")
-        
+
         # Apply semantic filter and search
         filtered_df = df.sem_filter("{Course Name} is related to cooking")
         result = filtered_df.sem_search("Course Name", "advanced level courses", K=2)
-        
+
         assert len(result) == 2
         # Should only return cooking-related courses
         assert all(dept == "Culinary" for dept in result["Department"])
@@ -69,12 +67,12 @@ class TestSearch(BaseTest):
         """Test semantic search with both relational and semantic filters"""
         # Index the dataframe
         df = sample_df.sem_index("Course Name", "course_index")
-        
+
         # Apply both filters and search
         filtered_df = df[df["Level"] >= 200]  # relational filter
         filtered_df = filtered_df.sem_filter("{Course Name} is related to computer science")  # semantic filter
         result = filtered_df.sem_search("Course Name", "data structures and algorithms", K=2)
-        
+
         assert len(result) == 2
         # Should only return advanced CS courses
         assert all(dept == "CS" for dept in result["Department"])
@@ -85,26 +83,32 @@ class TestSearch(BaseTest):
     def test_filtered_search_empty_result(self, sample_df):
         """Test semantic search when filter returns empty result"""
         df = sample_df.sem_index("Course Name", "course_index")
-        
+
         # Apply filter that should return no results
         filtered_df = df[df["Level"] > 1000]
         result = filtered_df.sem_search("Course Name", "any course", K=2)
-        
+
         assert len(result) == 0
 
     def test_filtered_search_with_scores(self, sample_df):
         """Test filtered semantic search with similarity scores"""
         df = sample_df.sem_index("Course Name", "course_index")
-        
+
         filtered_df = df[df["Department"] == "CS"]
-        result = filtered_df.sem_search(
-            "Course Name", 
-            "programming courses", 
-            K=2, 
-            return_scores=True
-        )
-        
+        result = filtered_df.sem_search("Course Name", "programming courses", K=2, return_scores=True)
+
         assert "vec_scores_sim_score" in result.columns
         assert len(result["vec_scores_sim_score"]) == 2
         # Scores should be between 0 and 1
-        assert all(0 <= score <= 1 for score in result["vec_scores_sim_score"]) 
+        assert all(0 <= score <= 1 for score in result["vec_scores_sim_score"])
+
+
+class TestFilterWithProbs(BaseTest):
+    def test_filter_with_probs(self, sample_df):
+        """Test semantic filter with probabilities returned to the user"""
+        lm = LM(model="gpt-4o-mini")
+        lotus.settings.configure(lm=lm)
+        result, stats = sample_df.sem_filter("{Course Name} is useful for life", return_stats=True)
+        print(result)
+        print(stats)
+        assert "probs" in stats


### PR DESCRIPTION
Introduces `return_probs`. Output can look like
```
                   Course Name Department  Level  filter_label  probs_filter
0  Introduction to Programming         CS    100         False      0.001927
1         Advanced Programming         CS    200         False      0.000024
2               Cooking Basics   Culinary    100          True      0.880797
3       Advanced Culinary Arts   Culinary    200          True      0.851953
4              Data Structures         CS    300         False      0.000261
5                   Algorithms         CS    300         False      0.000553
6               French Cuisine   Culinary    200          True      0.985936
7              Italian Cooking   Culinary    200          True      0.997527
```
Or
```
              Course Name Department  Level  probs_filter
2          Cooking Basics   Culinary    100      0.851953
3  Advanced Culinary Arts   Culinary    200      0.851953
6          French Cuisine   Culinary    200      0.985936
7         Italian Cooking   Culinary    200      0.999665
```
Depending on if `return_all` is set.


This PR also fixes a bug in the way that logprobs were analyzed for the True/False prob calculations.