### PR TITLE
DeepSeek CoT Support for Filter and Map

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -65,6 +65,7 @@ LOTUS implements the semantic operator programming model and provides an optimiz
    approximation_cascades
    prompt_strategies
    configurations
+   reasoning_models
 
 .. toctree::
    :hidden:

--- a/docs/prompt_strategies.rst
+++ b/docs/prompt_strategies.rst
@@ -4,8 +4,8 @@ Prompt Strategies
 Overview
 ----------
 In addition to calling the semantic operators, advanced prompt stratigies can be used to potentially
-get or improve the desired output. Two Prompt Strategies that can be used are Chain of Thought (CoT) and 
-Demonstrations.
+get or improve the desired output. Lotus supports multiple reasoning strategies through the 
+ReasoningStrategy enum. 
 
 Chain of Thought + Demonstrations:
 ----------------------------------
@@ -13,7 +13,7 @@ Chain of Thought reasoning refers to structing prompts in a way that guides the 
 to arrive at a final answer. By breaking down complex tasks into intermediate steps, CoT ensures more accurate and 
 logical output
 
-Here is a simple example of using chain of thought with the Semantic Filter operator
+Here is a simple example of using chain of thought with the Semantic Filter operator using COT
 
 .. code-block:: python
 
@@ -21,6 +21,7 @@ Here is a simple example of using chain of thought with the Semantic Filter oper
 
     import lotus
     from lotus.models import LM
+    from lotus.types import ReasoningStrategy
 
     lm = LM(model="gpt-4o-mini")
 
@@ -45,7 +46,7 @@ Here is a simple example of using chain of thought with the Semantic Filter oper
     }
     examples = pd.DataFrame(example_data)
 
-    df = df.sem_filter(user_instruction, examples=examples, strategy="cot")
+    df = df.sem_filter(user_instruction, examples=examples, strategy=ReasoningStrategy.COT)
     print(df)
 
 When calling the Semantic Filter operator, we pass in an example DataFrame as well as the CoT strategy, which acts as a guide 
@@ -66,3 +67,53 @@ Using the CoT strategy will provide an output below:
 +---+----------------------------------------+-------------------------------------------------------------------+
 | 2 | Digital Design and Integrated Circuits | Digital Design and Integrated Circuits typically covers...        |
 +---+-------------------------------------+----------------------------------------------------------------------+
+
+
+Here is another example that uses ZS_COT
+
+.. code-block:: python 
+
+    import pandas as pd
+
+    import lotus
+    from lotus.models import LM
+    from lotus.types import ReasoningStrategy
+
+    lm = LM(model="ollama/deepseek-r1:7b", temperature=0.6)
+    lotus.settings.configure(lm=lm)
+
+    data = {
+        "Review": [
+            "This vacuum cleaner is the best I've ever owned. Highly recommend it!",
+            "It's okay, not sure I would buy it again.",
+            "Terrible experience, broke after a few uses.",
+            "Amazing build quality and customer support. Would absolutely recommend.",
+        ]
+    }
+    df = pd.DataFrame(data)
+
+    user_instruction = "{Review} suggests that the user would recommend the product to others"
+
+    df = df.sem_filter(
+        user_instruction, 
+        strategy=ReasoningStrategy.ZS_COT, 
+        return_explanations=True,
+        return_all=True
+    )
+
+    print(df)
+
+
+Supported Reasoning Strategies
+-------------------------------
+ReasoningStrategy.DEFAULT
+* Description: The default strategy. The model receives a plain instruction and is expected to provide a direct answer without any explicit reasoning.
+
+ReasoningStrategy.COT (Chain of Thought)
+* Description: The model is prompted to reason step-by-step after being shown a few reasoning examples. Useful for tasks that benefit from intermediate steps to improve answer accuracy or interpretability.
+
+* ReasoningStrategy.ZS_COT (Zero-Shot Chain of Thought)
+Description: The model is instructed to reason step-by-step without examples. The reasoning process is triggered purely by the prompt (e.g., “Let’s think step by step”).
+
+ReasoningStrategy.FEW_SHOT
+* Description: The model is provided with few-shot examples, but without explicit reasoning steps. It imitates the behavior from the examples to answer the final prompt.

--- a/docs/reasoning_models.rst
+++ b/docs/reasoning_models.rst
@@ -1,0 +1,65 @@
+Reasoning Models
+=================
+
+Overview
+---------
+DeepSeek-R1, a lightweight yet powerful reasoning model optimized for CoT-style prompting. 
+When using DeepSeek-R1, we recommend setting the temperature between 0.5 and 0.7 (with 0.6 being ideal). 
+This range strikes a balance between deterministic reasoning and fluent generation. Lower temperatures (e.g., 0.2) may cause incomplete or overly terse reasoning, 
+while higher values (e.g., 0.9+) may lead to hallucination or incoherence.
+
+Filter Example
+---------------
+
+.. code-block:: python
+
+    import pandas as pd
+
+    import lotus
+    from lotus.models import LM
+
+    lm = LM(model="ollama/deepseek-r1:7b", temperature=0.5)
+
+    lotus.settings.configure(lm=lm)
+
+    data = {
+        "Reviews": [
+            "I absolutely love this product. It exceeded all my expectations.",
+            "Terrible experience. The product broke within a week.",
+            "The quality is average, nothing special.",
+            "Fantastic service and high quality!",
+            "I would not recommend this to anyone.",
+        ]
+    }
+    df = pd.DataFrame(data)
+    user_instruction = "{Reviews} are positive reviews"
+    df = df.sem_filter(user_instruction, return_explanations=True, return_all=True)
+
+    print(df)
+
+Map Example
+------------
+
+.. code-block:: python
+
+    import pandas as pd
+
+    import lotus
+    from lotus.models import LM
+    from lotus.types import ReasoningStrategy
+
+    lm = LM(model="ollama/deepseek-r1:7b", temperature=0.5)
+
+    lotus.settings.configure(lm=lm)
+    data = {
+        "Course Name": [
+            "Probability and Random Processes",
+            "Optimization Methods in Engineering",
+            "Digital Design and Integrated Circuits",
+            "Computer Security",
+        ]
+    }
+    df = pd.DataFrame(data)
+    user_instruction = "What is a similar course to {Course Name}. Just give the course name."
+    df = df.sem_map(user_instruction, return_explanations=True, strategy=ReasoningStrategy.ZS_COT)
+    print(df)

--- a/examples/op_examples/extract_deepseek_cot.py
+++ b/examples/op_examples/extract_deepseek_cot.py
@@ -1,0 +1,28 @@
+import pandas as pd
+
+import lotus
+from lotus.models import LM
+
+lm = LM(model="ollama/deepseek-r1:7b")
+lotus.settings.configure(lm=lm)
+
+df = pd.DataFrame(
+    {
+        "description": [
+            "Yoshi is 25 years old",
+            "Bowser is 45 years old",
+            "Luigi is 15 years old",
+        ]
+    }
+)
+input_cols = ["description"]
+
+# A description can be specified for each output column
+output_cols = {
+    "masked_col_1": "The name of the person",
+    "masked_col_2": "The age of the person",
+}
+
+# you can optionally set extract_quotes=True to return quotes that support each output
+new_df = df.sem_extract(input_cols, output_cols, extract_quotes=True, strategy="zs-cot", return_explanations=True)
+print(new_df)

--- a/examples/op_examples/extract_deepseek_cot.py
+++ b/examples/op_examples/extract_deepseek_cot.py
@@ -24,5 +24,5 @@ output_cols = {
 }
 
 # you can optionally set extract_quotes=True to return quotes that support each output
-new_df = df.sem_extract(input_cols, output_cols, extract_quotes=True, strategy="zs-cot", return_explanations=True)
+new_df = df.sem_extract(input_cols, output_cols, extract_quotes=True, return_explanations=True)
 print(new_df)

--- a/examples/op_examples/filter_deepseek_cot.py
+++ b/examples/op_examples/filter_deepseek_cot.py
@@ -1,0 +1,25 @@
+import pandas as pd
+
+import lotus
+from lotus.models import LM
+from lotus.sem_ops.postprocessors import deepseek_cot_postprocessor
+
+lm = LM(model="ollama/deepseek-r1:7b")
+
+lotus.settings.configure(lm=lm)
+
+data = {
+    "Reviews": [
+        "I absolutely love this product. It exceeded all my expectations.",
+        "Terrible experience. The product broke within a week.",
+        "The quality is average, nothing special.",
+        "Fantastic service and high quality!",
+        "I would not recommend this to anyone.",
+    ]
+}
+df = pd.DataFrame(data)
+user_instruction = "{Reviews} are positive reviews"
+df = df.sem_filter(
+    user_instruction, return_explanations=True, return_all=True, reasoning_parser=deepseek_cot_postprocessor
+)
+print(df)

--- a/examples/op_examples/filter_deepseek_cot.py
+++ b/examples/op_examples/filter_deepseek_cot.py
@@ -2,7 +2,6 @@ import pandas as pd
 
 import lotus
 from lotus.models import LM
-from lotus.sem_ops.postprocessors import deepseek_cot_postprocessor
 
 lm = LM(model="ollama/deepseek-r1:7b")
 
@@ -19,7 +18,6 @@ data = {
 }
 df = pd.DataFrame(data)
 user_instruction = "{Reviews} are positive reviews"
-df = df.sem_filter(
-    user_instruction, return_explanations=True, return_all=True, reasoning_parser=deepseek_cot_postprocessor
-)
+df = df.sem_filter(user_instruction, return_explanations=True, return_all=True)
+
 print(df)

--- a/examples/op_examples/filter_deepseek_cot.py
+++ b/examples/op_examples/filter_deepseek_cot.py
@@ -3,7 +3,7 @@ import pandas as pd
 import lotus
 from lotus.models import LM
 
-lm = LM(model="ollama/deepseek-r1:7b")
+lm = LM(model="ollama/deepseek-r1:7b", temperature=0.5)
 
 lotus.settings.configure(lm=lm)
 

--- a/examples/op_examples/map_deepseek_cot.py
+++ b/examples/op_examples/map_deepseek_cot.py
@@ -15,6 +15,6 @@ data = {
     ]
 }
 df = pd.DataFrame(data)
-user_instruction = "What is a similar course to {Course Name}. Be concise."
+user_instruction = "What is a similar course to {Course Name}. Just give the course name."
 df = df.sem_map(user_instruction, strategy="zs-cot", return_explanations=True, model_type="deepseek")
 print(df)

--- a/examples/op_examples/map_deepseek_cot.py
+++ b/examples/op_examples/map_deepseek_cot.py
@@ -2,6 +2,7 @@ import pandas as pd
 
 import lotus
 from lotus.models import LM
+from lotus.types import ReasoningStrategy
 
 lm = LM(model="ollama/deepseek-r1:7b")
 
@@ -16,5 +17,5 @@ data = {
 }
 df = pd.DataFrame(data)
 user_instruction = "What is a similar course to {Course Name}. Just give the course name."
-df = df.sem_map(user_instruction, return_explanations=True, strategy="zs-cot")
+df = df.sem_map(user_instruction, return_explanations=True, strategy=ReasoningStrategy.ZS_COT)
 print(df)

--- a/examples/op_examples/map_deepseek_cot.py
+++ b/examples/op_examples/map_deepseek_cot.py
@@ -2,6 +2,7 @@ import pandas as pd
 
 import lotus
 from lotus.models import LM
+from lotus.sem_ops.postprocessors import deepseek_cot_postprocessor
 
 lm = LM(model="ollama/deepseek-r1:7b")
 
@@ -16,5 +17,5 @@ data = {
 }
 df = pd.DataFrame(data)
 user_instruction = "What is a similar course to {Course Name}. Just give the course name."
-df = df.sem_map(user_instruction, strategy="zs-cot", return_explanations=True, model_type="deepseek")
+df = df.sem_map(user_instruction, return_explanations=True, reasoning_parser=deepseek_cot_postprocessor)
 print(df)

--- a/examples/op_examples/map_deepseek_cot.py
+++ b/examples/op_examples/map_deepseek_cot.py
@@ -2,7 +2,6 @@ import pandas as pd
 
 import lotus
 from lotus.models import LM
-from lotus.sem_ops.postprocessors import deepseek_cot_postprocessor
 
 lm = LM(model="ollama/deepseek-r1:7b")
 
@@ -17,5 +16,5 @@ data = {
 }
 df = pd.DataFrame(data)
 user_instruction = "What is a similar course to {Course Name}. Just give the course name."
-df = df.sem_map(user_instruction, return_explanations=True, reasoning_parser=deepseek_cot_postprocessor)
+df = df.sem_map(user_instruction, return_explanations=True, strategy="zs-cot")
 print(df)

--- a/examples/op_examples/map_deepseek_cot.py
+++ b/examples/op_examples/map_deepseek_cot.py
@@ -1,0 +1,20 @@
+import pandas as pd
+
+import lotus
+from lotus.models import LM
+
+lm = LM(model="ollama/deepseek-r1:7b")
+
+lotus.settings.configure(lm=lm)
+data = {
+    "Course Name": [
+        "Probability and Random Processes",
+        "Optimization Methods in Engineering",
+        "Digital Design and Integrated Circuits",
+        "Computer Security",
+    ]
+}
+df = pd.DataFrame(data)
+user_instruction = "What is a similar course to {Course Name}. Be concise."
+df = df.sem_map(user_instruction, strategy="zs-cot", return_explanations=True, model_type="deepseek")
+print(df)

--- a/examples/op_examples/map_deepseek_cot.py
+++ b/examples/op_examples/map_deepseek_cot.py
@@ -4,7 +4,7 @@ import lotus
 from lotus.models import LM
 from lotus.types import ReasoningStrategy
 
-lm = LM(model="ollama/deepseek-r1:7b")
+lm = LM(model="ollama/deepseek-r1:7b", temperature=0.5)
 
 lotus.settings.configure(lm=lm)
 data = {

--- a/lotus/models/lm.py
+++ b/lotus/models/lm.py
@@ -287,3 +287,20 @@ class LM:
 
     def reset_cache(self, max_size: int | None = None):
         self.cache.reset(max_size)
+
+    def get_model_name(self) -> str:
+        raw_model = self.model
+        if not raw_model:
+            return ""
+
+        # If a slash is present, assume the model name is after the last slash.
+        if "/" in raw_model:
+            candidate = raw_model.split("/")[-1]
+        else:
+            candidate = raw_model
+
+        # If a colon is present, assume the model version is appended and remove it.
+        if ":" in candidate:
+            candidate = candidate.split(":")[0]
+
+        return candidate.lower()

--- a/lotus/sem_ops/postprocessors.py
+++ b/lotus/sem_ops/postprocessors.py
@@ -98,10 +98,10 @@ def get_cot_postprocessor(model: lotus.models.LM, for_extract: bool = False) -> 
         Callable: The appropriate postprocessor function.
     """
     model_name = model.get_model_name()
-
-    if model_name in COT_POSTPROCESSORS:
-        base_processor = COT_POSTPROCESSORS[model_name]
-        return lambda llm_answers: base_processor(llm_answers, for_extract=for_extract)
+    for processor_key in COT_POSTPROCESSORS:
+        if model_name.startswith(processor_key):
+            base_processor = COT_POSTPROCESSORS[processor_key]
+            return lambda llm_answers: base_processor(llm_answers, for_extract=for_extract)
 
     return cot_postprocessor
 

--- a/lotus/sem_ops/sem_extract.py
+++ b/lotus/sem_ops/sem_extract.py
@@ -20,7 +20,6 @@ def sem_extract(
     postprocessor: Callable[[list[str], bool], SemanticExtractPostprocessOutput] = extract_postprocess,
     safe_mode: bool = False,
     progress_bar_desc: str = "Extracting",
-    strategy: str | None = None,
     return_explanations: bool = False,
 ) -> SemanticExtractOutput:
     """
@@ -57,7 +56,7 @@ def sem_extract(
     lm_output: LMOutput = model(inputs, response_format={"type": "json_object"}, progress_bar_desc=progress_bar_desc)
 
     # post process results
-    postprocess_output = postprocessor(lm_output.outputs, strategy in ["zs-cot"])
+    postprocess_output = postprocessor(lm_output.outputs, return_explanations)
     lotus.logger.debug(f"raw_outputs: {lm_output.outputs}")
     lotus.logger.debug(f"outputs: {postprocess_output.outputs}")
     lotus.logger.debug(f"explanations: {postprocess_output.explanations}")
@@ -92,7 +91,6 @@ class SemExtractDataFrame:
         return_raw_outputs: bool = False,
         safe_mode: bool = False,
         progress_bar_desc: str = "Extracting",
-        strategy: str | None = None,
         return_explanations: bool = False,
     ) -> pd.DataFrame:
         """
@@ -128,7 +126,6 @@ class SemExtractDataFrame:
             postprocessor=postprocessor,
             safe_mode=safe_mode,
             progress_bar_desc=progress_bar_desc,
-            strategy=strategy,
             return_explanations=return_explanations,
         )
 

--- a/lotus/sem_ops/sem_filter.py
+++ b/lotus/sem_ops/sem_filter.py
@@ -1,4 +1,4 @@
-from typing import Any
+from typing import Any, Callable, Tuple
 
 import numpy as np
 import pandas as pd
@@ -11,7 +11,7 @@ from lotus.types import CascadeArgs, LMOutput, LogprobsForFilterCascade, ProxyMo
 from lotus.utils import show_safe_mode
 
 from .cascade_utils import calibrate_llm_logprobs, importance_sampling, learn_cascade_thresholds
-from .postprocessors import filter_postprocess
+from .postprocessors import deepseek_cot_postprocessor, filter_postprocess
 
 
 def sem_filter(
@@ -28,6 +28,7 @@ def sem_filter(
     show_progress_bar: bool = True,
     progress_bar_desc: str = "Filtering",
     additional_cot_instructions: str = "",
+    reasoning_parser: Callable[[list[str], bool], Tuple] | None = None,
 ) -> SemanticFilterOutput:
     """
     Filters a list of documents based on a given user instruction using a language model.
@@ -48,15 +49,26 @@ def sem_filter(
     """
     inputs = []
     for doc in docs:
-        prompt = lotus.templates.task_instructions.filter_formatter(
-            doc,
-            user_instruction,
-            examples_multimodal_data,
-            examples_answers,
-            cot_reasoning,
-            strategy,
-            reasoning_instructions=additional_cot_instructions,
-        )
+        if reasoning_parser == deepseek_cot_postprocessor:
+            prompt = lotus.templates.task_instructions.deepseek_filter_formatter(
+                doc,
+                user_instruction,
+                examples_multimodal_data,
+                examples_answers,
+                cot_reasoning,
+                strategy,
+                reasoning_instructions=additional_cot_instructions,
+            )
+        else:
+            prompt = lotus.templates.task_instructions.filter_formatter(
+                doc,
+                user_instruction,
+                examples_multimodal_data,
+                examples_answers,
+                cot_reasoning,
+                strategy,
+                reasoning_instructions=additional_cot_instructions,
+            )
         lotus.logger.debug(f"input to model: {prompt}")
         inputs.append(prompt)
     kwargs: dict[str, Any] = {"logprobs": logprobs}
@@ -70,7 +82,7 @@ def sem_filter(
         inputs, show_progress_bar=show_progress_bar, progress_bar_desc=progress_bar_desc, **kwargs
     )
 
-    postprocess_output = filter_postprocess(lm_output.outputs, default=default)
+    postprocess_output = filter_postprocess(lm_output.outputs, default, deepseek_cot_postprocessor)
     lotus.logger.debug(f"outputs: {postprocess_output.outputs}")
     lotus.logger.debug(f"raw_outputs: {postprocess_output.raw_outputs}")
     lotus.logger.debug(f"explanations: {postprocess_output.explanations}")
@@ -99,6 +111,7 @@ def learn_filter_cascade_thresholds(
     cot_reasoning: list[str] | None = None,
     strategy: str | None = None,
     additional_cot_instructions: str = "",
+    reasoning_parser: Callable[[list[str], bool], Tuple] | None = None,
 ) -> tuple[float, float]:
     """Automatically learns the cascade thresholds for a cascade
     filter given a sample of data and doing a search across threshold
@@ -117,6 +130,7 @@ def learn_filter_cascade_thresholds(
             safe_mode=False,
             progress_bar_desc="Running oracle for threshold learning",
             additional_cot_instructions=additional_cot_instructions,
+            reasoning_parser=reasoning_parser,
         ).outputs
 
         best_combination, _ = learn_cascade_thresholds(
@@ -165,6 +179,7 @@ class SemFilterDataframe:
         safe_mode: bool = False,
         progress_bar_desc: str = "Filtering",
         additional_cot_instructions: str = "",
+        reasoning_parser: Callable[[list[str], bool], Tuple] | None = None,
     ) -> pd.DataFrame | tuple[pd.DataFrame, dict[str, Any]]:
         """
         Applies semantic filter over a dataframe.
@@ -265,6 +280,7 @@ class SemFilterDataframe:
                     safe_mode=safe_mode,
                     show_progress_bar=True,
                     progress_bar_desc="Running helper LM",
+                    reasoning_parser=reasoning_parser,
                 )
                 _, helper_logprobs = helper_output.outputs, helper_output.logprobs
                 assert helper_logprobs is not None
@@ -359,6 +375,7 @@ class SemFilterDataframe:
                     safe_mode=safe_mode,
                     progress_bar_desc="Running predicate evals with oracle LM",
                     additional_cot_instructions=additional_cot_instructions,
+                    reasoning_parser=reasoning_parser,
                 )
 
                 for idx, large_idx in enumerate(low_conf_idxs):
@@ -383,6 +400,7 @@ class SemFilterDataframe:
                 show_progress_bar=True,
                 progress_bar_desc=progress_bar_desc,
                 additional_cot_instructions=additional_cot_instructions,
+                reasoning_parser=reasoning_parser,
             )
             outputs = output.outputs
             raw_outputs = output.raw_outputs

--- a/lotus/sem_ops/sem_filter.py
+++ b/lotus/sem_ops/sem_filter.py
@@ -7,7 +7,14 @@ from numpy.typing import NDArray
 import lotus
 from lotus.cache import operator_cache
 from lotus.templates import task_instructions
-from lotus.types import CascadeArgs, LMOutput, LogprobsForFilterCascade, ProxyModel, SemanticFilterOutput
+from lotus.types import (
+    CascadeArgs,
+    LMOutput,
+    LogprobsForFilterCascade,
+    ProxyModel,
+    ReasoningStrategy,
+    SemanticFilterOutput,
+)
 from lotus.utils import show_safe_mode
 
 from .cascade_utils import calibrate_llm_logprobs, importance_sampling, learn_cascade_thresholds
@@ -22,7 +29,7 @@ def sem_filter(
     examples_multimodal_data: list[dict[str, Any]] | None = None,
     examples_answers: list[bool] | None = None,
     cot_reasoning: list[str] | None = None,
-    strategy: str | None = None,
+    strategy: ReasoningStrategy | None = None,
     logprobs: bool = False,
     safe_mode: bool = False,
     show_progress_bar: bool = True,
@@ -98,7 +105,7 @@ def learn_filter_cascade_thresholds(
     examples_multimodal_data: list[dict[str, Any]] | None = None,
     examples_answers: list[bool] | None = None,
     cot_reasoning: list[str] | None = None,
-    strategy: str | None = None,
+    strategy: ReasoningStrategy | None = None,
     additional_cot_instructions: str = "",
 ) -> tuple[float, float]:
     """Automatically learns the cascade thresholds for a cascade
@@ -160,7 +167,7 @@ class SemFilterDataframe:
         suffix: str = "_filter",
         examples: pd.DataFrame | None = None,
         helper_examples: pd.DataFrame | None = None,
-        strategy: str | None = None,
+        strategy: ReasoningStrategy | None = None,
         cascade_args: CascadeArgs | None = None,
         return_stats: bool = False,
         safe_mode: bool = False,
@@ -217,7 +224,7 @@ class SemFilterDataframe:
             examples_multimodal_data = task_instructions.df2multimodal_info(examples, col_li)
             examples_answers = examples["Answer"].tolist()
 
-            if strategy == "cot" and "Reasoning" in examples.columns:
+            if strategy == ReasoningStrategy.COT and "Reasoning" in examples.columns:
                 cot_reasoning = examples["Reasoning"].tolist()
 
         pos_cascade_threshold, neg_cascade_threshold = None, None
@@ -230,7 +237,7 @@ class SemFilterDataframe:
                 assert "Answer" in helper_examples.columns, "Answer must be a column in examples dataframe"
                 helper_examples_multimodal_data = task_instructions.df2multimodal_info(helper_examples, col_li)
                 helper_examples_answers = helper_examples["Answer"].tolist()
-                if helper_strategy == "cot" and "Reasoning" in helper_examples.columns:
+                if helper_strategy == ReasoningStrategy.COT and "Reasoning" in helper_examples.columns:
                     helper_cot_reasoning = helper_examples["Reasoning"].tolist()
 
         if cascade_args:
@@ -249,7 +256,7 @@ class SemFilterDataframe:
                 if not lotus.settings.helper_lm:
                     raise ValueError("Helper LM must be set in settings")
 
-                if helper_strategy == "cot":
+                if helper_strategy == ReasoningStrategy.COT:
                     raise ValueError("CoT not supported for helper models in cascades.")
 
                 # Run small LM and get logits

--- a/lotus/sem_ops/sem_join.py
+++ b/lotus/sem_ops/sem_join.py
@@ -64,7 +64,13 @@ def sem_join(
         sample_docs = task_instructions.merge_multimodal_info([left_multimodal_data[0]], right_multimodal_data)
         estimated_tokens_per_call = model.count_tokens(
             lotus.templates.task_instructions.filter_formatter(
-                sample_docs[0], user_instruction, examples_multimodal_data, examples_answers, cot_reasoning, strategy
+                model,
+                sample_docs[0],
+                user_instruction,
+                examples_multimodal_data,
+                examples_answers,
+                cot_reasoning,
+                strategy,
             )
         )
         estimated_total_calls = len(l1) * len(l2)

--- a/lotus/sem_ops/sem_join.py
+++ b/lotus/sem_ops/sem_join.py
@@ -6,7 +6,7 @@ from tqdm import tqdm
 import lotus
 from lotus.cache import operator_cache
 from lotus.templates import task_instructions
-from lotus.types import CascadeArgs, SemanticJoinOutput
+from lotus.types import CascadeArgs, ReasoningStrategy, SemanticJoinOutput
 from lotus.utils import show_safe_mode
 
 from .cascade_utils import calibrate_sem_sim_join, importance_sampling, learn_cascade_thresholds
@@ -26,7 +26,7 @@ def sem_join(
     examples_answers: list[bool] | None = None,
     cot_reasoning: list[str] | None = None,
     default: bool = True,
-    strategy: str | None = None,
+    strategy: ReasoningStrategy | None = None,
     safe_mode: bool = False,
     show_progress_bar: bool = True,
     progress_bar_desc: str = "Join comparisons",
@@ -152,7 +152,7 @@ def sem_join_cascade(
     map_examples: pd.DataFrame | None = None,
     cot_reasoning: list[str] | None = None,
     default: bool = True,
-    strategy: str | None = None,
+    strategy: ReasoningStrategy | None = None,
     safe_mode: bool = False,
 ) -> SemanticJoinOutput:
     """
@@ -387,7 +387,7 @@ def join_optimizer(
     map_examples: pd.DataFrame | None = None,
     cot_reasoning: list[str] | None = None,
     default: bool = True,
-    strategy: str | None = None,
+    strategy: ReasoningStrategy | None = None,
 ) -> tuple[pd.DataFrame, pd.DataFrame, int, int]:
     """
     Find most cost-effective join plan between Search-Filter and Map-Search-Filter
@@ -497,7 +497,7 @@ def learn_join_cascade_threshold(
     examples_answers: list[bool] | None = None,
     cot_reasoning: list[str] | None = None,
     default: bool = True,
-    strategy: str | None = None,
+    strategy: ReasoningStrategy | None = None,
 ) -> tuple[float, float, int]:
     """
     Extract a small sample of the data and find the optimal threshold pair that satisfies the recall and
@@ -584,7 +584,7 @@ class SemJoinDataframe:
         how: str = "inner",
         suffix: str = "_join",
         examples: pd.DataFrame | None = None,
-        strategy: str | None = None,
+        strategy: ReasoningStrategy | None = None,
         default: bool = True,
         cascade_args: CascadeArgs | None = None,
         return_stats: bool = False,
@@ -670,7 +670,7 @@ class SemJoinDataframe:
             examples_multimodal_data = task_instructions.df2multimodal_info(examples, [real_left_on, real_right_on])
             examples_answers = examples["Answer"].tolist()
 
-            if strategy == "cot":
+            if strategy == ReasoningStrategy.COT:
                 return_explanations = True
                 cot_reasoning = examples["Reasoning"].tolist()
 

--- a/lotus/sem_ops/sem_map.py
+++ b/lotus/sem_ops/sem_map.py
@@ -43,7 +43,7 @@ def sem_map(
     inputs = []
     for doc in docs:
         if model_type == "deepseek":
-            prompt = lotus.templates.task_instructions.deepseek_prompt_formatter(
+            prompt = lotus.templates.task_instructions.deepseek_map_formatter(
                 doc,
                 user_instruction,
                 examples_multimodal_data,

--- a/lotus/sem_ops/sem_map.py
+++ b/lotus/sem_ops/sem_map.py
@@ -6,7 +6,7 @@ import lotus
 from lotus.cache import operator_cache
 from lotus.templates import task_instructions
 from lotus.types import LMOutput, ReasoningStrategy, SemanticMapOutput, SemanticMapPostprocessOutput
-from lotus.utils import normalize_strategy, show_safe_mode
+from lotus.utils import show_safe_mode
 
 from .postprocessors import map_postprocess
 
@@ -19,7 +19,7 @@ def sem_map(
     examples_multimodal_data: list[dict[str, Any]] | None = None,
     examples_answers: list[str] | None = None,
     cot_reasoning: list[str] | None = None,
-    strategy: ReasoningStrategy | str | None = None,
+    strategy: ReasoningStrategy | None = None,
     safe_mode: bool = False,
     progress_bar_desc: str = "Mapping",
 ) -> SemanticMapOutput:
@@ -38,7 +38,6 @@ def sem_map(
     Returns:
         SemanticMapOutput: The outputs, raw outputs, and explanations.
     """
-    strategy = normalize_strategy(strategy)
 
     # prepare model inputs
     inputs = []
@@ -98,7 +97,7 @@ class SemMapDataframe:
         return_raw_outputs: bool = False,
         suffix: str = "_map",
         examples: pd.DataFrame | None = None,
-        strategy: ReasoningStrategy | str | None = None,
+        strategy: ReasoningStrategy | None = None,
         safe_mode: bool = False,
         progress_bar_desc: str = "Mapping",
     ) -> pd.DataFrame:
@@ -135,7 +134,6 @@ class SemMapDataframe:
         examples_multimodal_data = None
         examples_answers = None
         cot_reasoning = None
-        strategy = normalize_strategy(strategy)
 
         if examples is not None:
             assert "Answer" in examples.columns, "Answer must be a column in examples dataframe"

--- a/lotus/sem_ops/sem_map.py
+++ b/lotus/sem_ops/sem_map.py
@@ -15,13 +15,14 @@ def sem_map(
     docs: list[dict[str, Any]],
     model: lotus.models.LM,
     user_instruction: str,
-    postprocessor: Callable[[list[str], bool], SemanticMapPostprocessOutput] = map_postprocess,
+    postprocessor: Callable[[list[str], bool, str], SemanticMapPostprocessOutput] = map_postprocess,
     examples_multimodal_data: list[dict[str, Any]] | None = None,
     examples_answers: list[str] | None = None,
     cot_reasoning: list[str] | None = None,
     strategy: str | None = None,
     safe_mode: bool = False,
     progress_bar_desc: str = "Mapping",
+    model_type: str = "default",
 ) -> SemanticMapOutput:
     """
     Maps a list of documents to a list of outputs using a model.
@@ -41,9 +42,19 @@ def sem_map(
     # prepare model inputs
     inputs = []
     for doc in docs:
-        prompt = lotus.templates.task_instructions.map_formatter(
-            doc, user_instruction, examples_multimodal_data, examples_answers, cot_reasoning, strategy=strategy
-        )
+        if model_type == "deepseek":
+            prompt = lotus.templates.task_instructions.deepseek_prompt_formatter(
+                doc,
+                user_instruction,
+                examples_multimodal_data,
+                examples_answers,
+                cot_reasoning,
+                strategy=strategy,
+            )
+        else:
+            prompt = lotus.templates.task_instructions.map_formatter(
+                doc, user_instruction, examples_multimodal_data, examples_answers, cot_reasoning, strategy=strategy
+            )
         lotus.logger.debug(f"input to model: {prompt}")
         lotus.logger.debug(f"inputs content to model: {[x.get('content') for x in prompt]}")
         inputs.append(prompt)
@@ -58,7 +69,7 @@ def sem_map(
     lm_output: LMOutput = model(inputs, progress_bar_desc=progress_bar_desc)
 
     # post process results
-    postprocess_output = postprocessor(lm_output.outputs, strategy in ["cot", "zs-cot"])
+    postprocess_output = postprocessor(lm_output.outputs, strategy in ["cot", "zs-cot"], model_type)
     lotus.logger.debug(f"raw_outputs: {lm_output.outputs}")
     lotus.logger.debug(f"outputs: {postprocess_output.outputs}")
     lotus.logger.debug(f"explanations: {postprocess_output.explanations}")
@@ -89,7 +100,7 @@ class SemMapDataframe:
     def __call__(
         self,
         user_instruction: str,
-        postprocessor: Callable[[list[str], bool], SemanticMapPostprocessOutput] = map_postprocess,
+        postprocessor: Callable[[list[str], bool, str], SemanticMapPostprocessOutput] = map_postprocess,
         return_explanations: bool = False,
         return_raw_outputs: bool = False,
         suffix: str = "_map",
@@ -97,6 +108,7 @@ class SemMapDataframe:
         strategy: str | None = None,
         safe_mode: bool = False,
         progress_bar_desc: str = "Mapping",
+        model_type: str = "default",
     ) -> pd.DataFrame:
         """
         Applies semantic map over a dataframe.
@@ -151,6 +163,7 @@ class SemMapDataframe:
             strategy=strategy,
             safe_mode=safe_mode,
             progress_bar_desc=progress_bar_desc,
+            model_type=model_type,
         )
 
         new_df = self._obj.copy()

--- a/lotus/templates/task_instructions.py
+++ b/lotus/templates/task_instructions.py
@@ -5,8 +5,7 @@ import pandas as pd
 
 import lotus
 from lotus.dtype_extensions import ImageDtype
-from lotus.types import SerializationFormat
-from lotus.utils import get_model_name
+from lotus.types import ReasoningStrategy, SerializationFormat
 
 
 def cot_formatter(reasoning, answer):
@@ -104,7 +103,7 @@ def filter_formatter(
         sys_instruction += cot_prompt_formatter(
             reasoning_instructions=reasoning_instructions, answer_instructions=answer_instructions
         )
-    elif strategy == "zs-cot" and get_model_name(model) == "deepseek-r1":
+    elif strategy == "zs-cot" and model.get_model_name() == "deepseek-r1":
         sys_instruction += deepseek_cot_formatter()
     else:
         sys_instruction += non_cot_prompt_formatter(answer_instructions=answer_instructions)
@@ -210,7 +209,7 @@ def map_formatter(
     examples_multimodal_data: list[dict[str, Any]] | None = None,
     examples_answer: list[str] | None = None,
     cot_reasoning: list[str] | None = None,
-    strategy: str | None = None,
+    strategy: ReasoningStrategy | str | None = None,
 ) -> list[dict[str, str]]:
     sys_instruction = (
         "The user will provide an instruction and some relevant context.\n"
@@ -221,9 +220,9 @@ def map_formatter(
         return map_formatter_cot(
             multimodal_data, user_instruction, examples_multimodal_data, examples_answer, cot_reasoning
         )
-    elif strategy == "zs-cot" and get_model_name(model) == "deepseek-r1":
+    elif strategy == ReasoningStrategy.ZS_COT and model.get_model_name() == "deepseek-r1":
         sys_instruction += deepseek_cot_formatter()
-    elif strategy == "zs-cot":
+    elif strategy == ReasoningStrategy.ZS_COT:
         return map_formatter_zs_cot(multimodal_data, user_instruction)
 
     messages = [

--- a/lotus/templates/task_instructions.py
+++ b/lotus/templates/task_instructions.py
@@ -283,11 +283,11 @@ def deepseek_extract_cot_formatter(
 
     sys_instruction = (
         "The user will provide the columns that need to be extracted and some relevant context.\n"
-        "First you will reason and put your reasoing inside the <think></think> tags.\n"
+        "First you will reason and put your reasoning inside the <think></think> tags.\n"
         f"Then your next job is to extract these columns and provide only a concise value for each field "
         f"and the corresponding full quote for each field in the '{', '.join([f'{col}_quote' for col in output_col_names])}' fields.\n"
         f"Here is a description of each field: {output_cols_with_desc}\n"
-        f"The response should be valid JSON format with the following fields: {fields_str}.\n"
+        f"The answer should be valid JSON format with the following fields: {fields_str}.\n"
     )
 
     messages = [

--- a/lotus/templates/task_instructions.py
+++ b/lotus/templates/task_instructions.py
@@ -90,7 +90,7 @@ def filter_formatter(
     examples_multimodal_data: list[dict[str, Any]] | None = None,
     examples_answer: list[bool] | None = None,
     cot_reasoning: list[str] | None = None,
-    strategy: str | None = None,
+    strategy: ReasoningStrategy | None = None,
     reasoning_instructions: str = "",
 ) -> list[dict[str, str]]:
     answer_instructions = "The answer should be either True or False"
@@ -99,11 +99,11 @@ def filter_formatter(
     Your job is to determine whether the claim is true for the given context.
      """
 
-    if strategy == "cot":
+    if strategy == ReasoningStrategy.COT:
         sys_instruction += cot_prompt_formatter(
             reasoning_instructions=reasoning_instructions, answer_instructions=answer_instructions
         )
-    elif strategy == "zs-cot" and model.get_model_name() == "deepseek-r1":
+    elif strategy == ReasoningStrategy.ZS_COT and model.get_model_name() == "deepseek-r1":
         sys_instruction += deepseek_cot_formatter()
     else:
         sys_instruction += non_cot_prompt_formatter(answer_instructions=answer_instructions)

--- a/lotus/templates/task_instructions.py
+++ b/lotus/templates/task_instructions.py
@@ -78,6 +78,42 @@ def user_message_formatter(
     }
 
 
+def deepseek_prompt_formatter(
+    multimodal_data: dict[str, Any],
+    user_instruction: str,
+    examples_multimodal_data: list[dict[str, Any]] | None = None,
+    examples_answer: list[str] | None = None,
+    cot_reasoning: list[str] | None = None,
+    strategy: str | None = None,
+) -> list[dict[str, str]]:
+    sys_instruction = (
+        "The user will provide an instruction and some relevant context.\n"
+        "Your job is to answer the user's instruction given the context."
+        "You must put your reasoning inside the <think></think> tags, then provide your final answer after the </think> tag with the format: Answer: your answer."
+    )
+    messages = [
+        {"role": "system", "content": sys_instruction},
+    ]
+
+    if examples_multimodal_data and examples_answer:
+        for idx in range(len(examples_multimodal_data)):
+            example_data = examples_multimodal_data[idx]
+            example_answer = examples_answer[idx]
+
+            if cot_reasoning and idx < len(cot_reasoning):
+                example_content = f"<think>{cot_reasoning[idx]}</think>\n: {example_answer}"
+
+            messages.extend(
+                [
+                    user_message_formatter(example_data, f"Instruction: {user_instruction}"),
+                    {"role": "assistant", "content": example_content},
+                ]
+            )
+
+    messages.append(user_message_formatter(multimodal_data, f"Instruction: {user_instruction}"))
+    return messages
+
+
 def filter_formatter(
     multimodal_data: dict[str, Any],
     user_instruction: str,

--- a/lotus/templates/task_instructions.py
+++ b/lotus/templates/task_instructions.py
@@ -283,11 +283,13 @@ def deepseek_extract_cot_formatter(
 
     sys_instruction = (
         "The user will provide the columns that need to be extracted and some relevant context.\n"
-        "First you will reason and put your reasoning inside the <think></think> tags.\n"
-        f"Then your next job is to extract these columns and provide only a concise value for each field "
-        f"and the corresponding full quote for each field in the '{', '.join([f'{col}_quote' for col in output_col_names])}' fields.\n"
-        f"Here is a description of each field: {output_cols_with_desc}\n"
-        f"The answer should be valid JSON format with the following fields: {fields_str}.\n"
+        "Your task is to extract specific information into a JSON object.\n\n"
+        "Step 1: Analyze the context and provide your reasoning enclosed in <think> and </think> tags. "
+        "This reasoning should explain how you identified each field.\n\n"
+        "Step 2: After the </think> tag, output a JSON object that includes only the following fields: "
+        f"{fields_str}.\n\n"
+        f"Field Descriptions: {output_cols_with_desc}.\n"
+        "Ensure that the final output is valid JSON and does not include any extra text outside the JSON.\n"
     )
 
     messages = [

--- a/lotus/types.py
+++ b/lotus/types.py
@@ -84,12 +84,14 @@ class SemanticMapOutput:
 class SemanticExtractPostprocessOutput:
     raw_outputs: list[str]
     outputs: list[dict[str, str]]
+    explanations: list[str | None]
 
 
 @dataclass
 class SemanticExtractOutput:
     raw_outputs: list[str]
     outputs: list[dict[str, str]]
+    explanations: list[str | None]
 
 
 @dataclass

--- a/lotus/types.py
+++ b/lotus/types.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass, field
-from enum import Enum
+from enum import Enum, auto
 from typing import Any
 
 import pandas as pd
@@ -210,3 +210,13 @@ class LotusUsageLimitException(LotusException):
     """Exception raised when the usage limit is exceeded."""
 
     pass
+
+
+################################################################################
+# Reasoning Strategy
+################################################################################
+class ReasoningStrategy(Enum):
+    DEFAULT = auto()
+    COT = auto()
+    ZS_COT = auto()
+    FEW_SHOT = auto()

--- a/lotus/utils.py
+++ b/lotus/utils.py
@@ -9,6 +9,7 @@ import requests  # type: ignore
 from PIL import Image
 
 import lotus
+from lotus.types import ReasoningStrategy
 
 
 def cluster(col_name: str, ncentroids: int) -> Callable[[pd.DataFrame, int, bool], list[int]]:
@@ -134,19 +135,10 @@ def show_safe_mode(estimated_cost, estimated_LM_calls):
         exit(0)
 
 
-def get_model_name(model: "lotus.models.LM") -> str:
-    raw_model = getattr(model, "model", "")
-    if not raw_model:
-        return ""
-
-    # If a slash is present, assume the model name is after the last slash.
-    if "/" in raw_model:
-        candidate = raw_model.split("/")[-1]
-    else:
-        candidate = raw_model
-
-    # If a colon is present, assume the model version is appended and remove it.
-    if ":" in candidate:
-        candidate = candidate.split(":")[0]
-
-    return candidate.lower()
+def normalize_strategy(strategy: ReasoningStrategy | str | None) -> ReasoningStrategy | str | None:
+    if strategy is not None and isinstance(strategy, str):
+        if strategy.lower() == "cot":
+            return ReasoningStrategy.COT
+        elif strategy.lower() == "zs-cot":
+            return ReasoningStrategy.ZS_COT
+    return strategy

--- a/lotus/utils.py
+++ b/lotus/utils.py
@@ -40,7 +40,7 @@ def cluster(col_name: str, ncentroids: int) -> Callable[[pd.DataFrame, int, bool
 
         # get rmodel and index
         rm = lotus.settings.rm
-        vs = lotus.settings.vs 
+        vs = lotus.settings.vs
         if rm is None or vs is None:
             raise ValueError(
                 "The retrieval model must be an instance of RM, and the vector store must be an instance of VS. Please configure a valid retrieval model using lotus.settings.configure()"
@@ -132,3 +132,21 @@ def show_safe_mode(estimated_cost, estimated_LM_calls):
     except KeyboardInterrupt:
         print("\nExecution cancelled by user")
         exit(0)
+
+
+def get_model_name(model: "lotus.models.LM") -> str:
+    raw_model = getattr(model, "model", "")
+    if not raw_model:
+        return ""
+
+    # If a slash is present, assume the model name is after the last slash.
+    if "/" in raw_model:
+        candidate = raw_model.split("/")[-1]
+    else:
+        candidate = raw_model
+
+    # If a colon is present, assume the model version is appended and remove it.
+    if ":" in candidate:
+        candidate = candidate.split(":")[0]
+
+    return candidate.lower()

--- a/lotus/utils.py
+++ b/lotus/utils.py
@@ -9,7 +9,6 @@ import requests  # type: ignore
 from PIL import Image
 
 import lotus
-from lotus.types import ReasoningStrategy
 
 
 def cluster(col_name: str, ncentroids: int) -> Callable[[pd.DataFrame, int, bool], list[int]]:
@@ -133,12 +132,3 @@ def show_safe_mode(estimated_cost, estimated_LM_calls):
     except KeyboardInterrupt:
         print("\nExecution cancelled by user")
         exit(0)
-
-
-def normalize_strategy(strategy: ReasoningStrategy | str | None) -> ReasoningStrategy | str | None:
-    if strategy is not None and isinstance(strategy, str):
-        if strategy.lower() == "cot":
-            return ReasoningStrategy.COT
-        elif strategy.lower() == "zs-cot":
-            return ReasoningStrategy.ZS_COT
-    return strategy

--- a/tests/deepseek_cot_tests.py
+++ b/tests/deepseek_cot_tests.py
@@ -5,6 +5,7 @@ import pytest
 
 import lotus
 from lotus.models import LM
+from lotus.types import ReasoningStrategy
 
 lotus.logger.setLevel("DEBUG")
 
@@ -50,7 +51,7 @@ def test_deepseek_map_cot_basic():
     data = {"Text": ["Paris is the capital of France", "Berlin is the capital of Germany"]}
     df = pd.DataFrame(data)
     user_instruction = "Extract the capital city from the sentence: {Text}"
-    result = df.sem_map(user_instruction, return_explanations=True, strategy="zs-cot")
+    result = df.sem_map(user_instruction, return_explanations=True, strategy=ReasoningStrategy.ZS_COT)
 
     # Check that the mapping column and explanation column exist.
     assert "_map" in result.columns
@@ -92,7 +93,7 @@ def test_deepseek_filter_cot_fewshot():
         examples=examples,
         return_explanations=True,
         return_all=True,
-        strategy="cot",
+        strategy=ReasoningStrategy.COT,
     )
 
     # Expect that at least the row with "Sequence: 1, 2, 3" is marked positive.
@@ -124,7 +125,7 @@ def test_deepseek_map_cot_fewshot():
         user_instruction,
         examples=examples,
         return_explanations=True,
-        strategy="cot",
+        strategy=ReasoningStrategy.COT,
     )
 
     # Check that the new column "State" is added and that explanations are nonempty.

--- a/tests/deepseek_cot_tests.py
+++ b/tests/deepseek_cot_tests.py
@@ -5,7 +5,6 @@ import pytest
 
 import lotus
 from lotus.models import LM
-from lotus.sem_ops.postprocessors import deepseek_cot_postprocessor
 
 lotus.logger.setLevel("DEBUG")
 
@@ -27,9 +26,7 @@ def test_deepseek_filter_cot_basic():
     df = pd.DataFrame(data)
     user_instruction = "{Text} implies I have at least one apple"
 
-    filtered_df = df.sem_filter(
-        user_instruction, return_explanations=True, return_all=True, reasoning_parser=deepseek_cot_postprocessor
-    )
+    filtered_df = df.sem_filter(user_instruction, return_explanations=True, return_all=True)
 
     # Check that extra columns are present.
     assert "explanation_filter" in filtered_df.columns
@@ -53,7 +50,7 @@ def test_deepseek_map_cot_basic():
     data = {"Text": ["Paris is the capital of France", "Berlin is the capital of Germany"]}
     df = pd.DataFrame(data)
     user_instruction = "Extract the capital city from the sentence: {Text}"
-    result = df.sem_map(user_instruction, return_explanations=True, reasoning_parser=deepseek_cot_postprocessor)
+    result = df.sem_map(user_instruction, return_explanations=True, strategy="zs-cot")
 
     # Check that the mapping column and explanation column exist.
     assert "_map" in result.columns
@@ -95,7 +92,6 @@ def test_deepseek_filter_cot_fewshot():
         examples=examples,
         return_explanations=True,
         return_all=True,
-        reasoning_parser=deepseek_cot_postprocessor,
         strategy="cot",
     )
 
@@ -128,7 +124,6 @@ def test_deepseek_map_cot_fewshot():
         user_instruction,
         examples=examples,
         return_explanations=True,
-        reasoning_parser=deepseek_cot_postprocessor,
         strategy="cot",
     )
 

--- a/tests/deepseek_cot_tests.py
+++ b/tests/deepseek_cot_tests.py
@@ -1,0 +1,140 @@
+import os
+
+import pandas as pd
+import pytest
+
+import lotus
+from lotus.models import LM
+from lotus.sem_ops.postprocessors import deepseek_cot_postprocessor
+
+lotus.logger.setLevel("DEBUG")
+
+ENABLE_OLLAMA_TESTS = os.getenv("ENABLE_OLLAMA_TESTS", "false").lower() == "true"
+
+MODEL_NAME = "ollama/deepseek-r1:7b"
+
+
+@pytest.mark.skipif(not ENABLE_OLLAMA_TESTS, reason="Skipping test because Ollama tests are not enabled")
+def test_deepseek_filter_cot_basic():
+    """Test sem_filter using DeepSeek CoT on a simple filtering task."""
+    lm = LM(model=MODEL_NAME)
+    lotus.settings.configure(lm=lm)
+
+    data = {
+        "Text": ["I had two apples and still have one left", "I gave away all my apples", "I received an apple today"]
+    }
+
+    df = pd.DataFrame(data)
+    user_instruction = "{Text} implies I have at least one apple"
+
+    filtered_df = df.sem_filter(
+        user_instruction, return_explanations=True, return_all=True, reasoning_parser=deepseek_cot_postprocessor
+    )
+
+    # Check that extra columns are present.
+    assert "explanation_filter" in filtered_df.columns
+    assert "filter_label" in filtered_df.columns
+
+    # At least one row should be labeled True.
+    positive_rows = filtered_df[filtered_df["filter_label"]]
+    assert len(positive_rows) > 0
+
+    # Each explanation should be nonempty for positive rows.
+    for exp in positive_rows["explanation_filter"]:
+        assert exp is not None and exp != ""
+
+
+@pytest.mark.skipif(not ENABLE_OLLAMA_TESTS, reason="Skipping test because Ollama tests are not enabled")
+def test_deepseek_map_cot_basic():
+    """Test sem_map using DeepSeek CoT on a basic mapping task."""
+    lm = LM(model=MODEL_NAME)
+    lotus.settings.configure(lm=lm)
+
+    data = {"Text": ["Paris is the capital of France", "Berlin is the capital of Germany"]}
+    df = pd.DataFrame(data)
+    user_instruction = "Extract the capital city from the sentence: {Text}"
+    result = df.sem_map(user_instruction, return_explanations=True, reasoning_parser=deepseek_cot_postprocessor)
+
+    # Check that the mapping column and explanation column exist.
+    assert "_map" in result.columns
+    assert "explanation_map" in result.columns
+
+    # Verify that each mapped output is a string and each explanation is nonempty.
+    for output, exp in zip(result["_map"], result["explanation_map"]):
+        assert isinstance(output, str)
+        assert exp is not None and exp != ""
+
+
+@pytest.mark.skipif(not ENABLE_OLLAMA_TESTS, reason="Skipping test because Ollama tests are not enabled")
+def test_deepseek_filter_cot_fewshot():
+    """Test sem_filter with few-shot examples to guide filtering decisions."""
+    lm = LM(model=MODEL_NAME)
+    lotus.settings.configure(lm=lm)
+
+    data = {
+        "Text": [
+            "Sequence: 5, 4, 3",  # Not increasing
+            "Sequence: 1, 2, 3",  # Increasing
+            "Sequence: 8, 7, 6",  # Not increasing
+        ]
+    }
+    df = pd.DataFrame(data)
+    user_instruction = "{Text} is an increasing sequence"
+
+    # Few-shot examples provided as a DataFrame.
+    examples = pd.DataFrame(
+        {
+            "Text": ["Sequence: 1, 2, 3", "Sequence: 3, 2, 1"],
+            "Answer": [True, False],
+            "Reasoning": ["Numbers increase steadily", "Numbers decrease"],
+        }
+    )
+
+    filtered_df = df.sem_filter(
+        user_instruction,
+        examples=examples,
+        return_explanations=True,
+        return_all=True,
+        reasoning_parser=deepseek_cot_postprocessor,
+        strategy="cot",
+    )
+
+    # Expect that at least the row with "Sequence: 1, 2, 3" is marked positive.
+    positive_rows = filtered_df[filtered_df["filter_label"]]
+    assert len(positive_rows) >= 1
+    for exp in positive_rows["explanation_filter"]:
+        assert exp is not None and exp != ""
+
+
+@pytest.mark.skipif(not ENABLE_OLLAMA_TESTS, reason="Skipping test because Ollama tests are not enabled")
+def test_deepseek_map_cot_fewshot():
+    """Test sem_map with few-shot examples to guide mapping decisions."""
+    lm = LM(model=MODEL_NAME)
+    lotus.settings.configure(lm=lm)
+
+    data = {"Text": ["City: New York", "City: Los Angeles"]}
+    df = pd.DataFrame(data)
+    user_instruction = "Determine the state abbreviation for {Text}"
+
+    examples = pd.DataFrame(
+        {
+            "Text": ["City: Chicago", "City: Houston"],
+            "Answer": ["IL", "TX"],
+            "Reasoning": ["Chicago is in Illinois", "Houston is in Texas"],
+        }
+    )
+
+    result = df.sem_map(
+        user_instruction,
+        examples=examples,
+        return_explanations=True,
+        reasoning_parser=deepseek_cot_postprocessor,
+        strategy="cot",
+    )
+
+    # Check that the new column "State" is added and that explanations are nonempty.
+    assert "_map" in result.columns
+    assert "explanation_map" in result.columns
+    for output, exp in zip(result["_map"], result["explanation_map"]):
+        assert isinstance(output, str)
+        assert exp is not None and exp != ""


### PR DESCRIPTION
Introduces CoT for `sem_extract` as well as supporting DeepSeek-R1 CoT for other semantic operators. 

Example output with `sem_map`:
```                              Course Name                                          _map                                    explanation_map
0        Probability and Random Processes  Applied Probability and Stochastic Processes  Okay, so I need to figure out what a similar c...
1     Optimization Methods in Engineering                      Engineering Optimization  Okay, so I need to figure out what a similar c...
2  Digital Design and Integrated Circuits                          Digital Logic Design  Okay, so I need to figure out what a similar c...
3                       Computer Security                                 Cybersecurity  Okay, so I need to figure out what a similar c...
```
Example output with `sem_filter`:
```
                                             Reviews  filter_label                                 explanation_filter
0  I absolutely love this product. It exceeded al...          True  Okay, so I need to figure out if the claim is ...
1  Terrible experience. The product broke within ...         False  Okay, so I need to determine whether the claim...
2           The quality is average, nothing special.         False  Okay, so I need to figure out whether the clai...
3                Fantastic service and high quality!          True  Okay, so I need to determine if the claim is t...
4              I would not recommend this to anyone.         False  Okay, so I need to determine whether the claim...
```

Users will need to specify the reasoning_parser. Example:
```df = df.sem_map(user_instruction, return_explanations=True, strategy=ReasoningStrategy.ZS_COT)```

New Type for models: `ReasoningStrategy(Enum)`