### PR TITLE
Optional dependencies for data connectors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,11 @@ pdf_parser = [
 weaviate = [
     "weaviate-client",
 ]
+data_connectors = [
+    "sqlalchemy",
+    "boto3",
+    "io",
+]
 
 [tool.ruff]
 line-length = 120


### PR DESCRIPTION
Added Optional Dependencies for data connector: Includes sqlalchemy, boto3, and IO