### PR TITLE
Fix: Ensure model and stats are set before using operator cache

### DIFF
--- a/lotus/cache.py
+++ b/lotus/cache.py
@@ -35,6 +35,11 @@ def operator_cache(func: Callable) -> Callable:
     @wraps(func)
     def wrapper(self, *args, **kwargs):
         model = lotus.settings.lm
+
+        if not model:
+            raise ValueError("Model is not set in the current context.")
+        if not model.stats:
+            raise ValueError("Model stats are not set in the current context.")
         use_operator_cache = lotus.settings.enable_cache
 
         if use_operator_cache and model.cache:
@@ -83,9 +88,9 @@ def operator_cache(func: Callable) -> Callable:
                 return cached_result
             lotus.logger.debug(f"Cache miss for {cache_key}")
 
-            virtual_usage_before = copy.deepcopy(lotus.settings.lm.stats.virtual_usage)
+            virtual_usage_before = copy.deepcopy(model.stats.virtual_usage)
             result = func(self, *args, **kwargs)
-            virtual_usage = lotus.settings.lm.stats.virtual_usage - virtual_usage_before
+            virtual_usage = model.stats.virtual_usage - virtual_usage_before
             model.cache.insert(virtual_usage_cache_key, virtual_usage)
             model.cache.insert(cache_key, result)
             return result


### PR DESCRIPTION
Fix some type errors with accessors.

```
0 errors, 0 warnings, 0 informations 
```

Before:

```
lotus/lotus/cache.py
   error: "cache" is not a known attribute of "None" (reportOptionalMemberAccess)
 error: "cache" is not a known attribute of "None" (reportOptionalMemberAccess)
  error: "stats" is not a known attribute of "None" (reportOptionalMemberAccess)
  error: "cache" is not a known attribute of "None" (reportOptionalMemberAccess)
  error: "stats" is not a known attribute of "None" (reportOptionalMemberAccess)
  error: "stats" is not a known attribute of "None" (reportOptionalMemberAccess)
  error: "stats" is not a known attribute of "None" (reportOptionalMemberAccess)
  error: "cache" is not a known attribute of "None" (reportOptionalMemberAccess)
  error: "cache" is not a known attribute of "None" (reportOptionalMemberAccess)
9 errors, 0 warnings, 0 informations 
```