### PR TITLE
Update requirements.txt upgrading litellm version number to fix litellm provider bugs for WatsonX

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 backoff==2.2.1
 faiss-cpu==1.8.0.post1
-litellm==1.51.0,<2.0.0
+litellm==1.68.1,<2.0.0
 numpy==1.26.4
 pandas==2.2.2
 sentence-transformers==3.0.1


### PR DESCRIPTION
litellm version number update to 1.68.1 fixes bugs in the WatsonX provider.  Older version 1.51.0 of litellm contains bugs that causes failures when connecting to a WatsonX endpoint.