### PR TITLE
Fix logprobs bug from litellm version upgrade

### DIFF
--- a/lotus/models/lm.py
+++ b/lotus/models/lm.py
@@ -275,7 +275,7 @@ class LM:
         choice = response.choices[0]
         assert isinstance(choice, Choices)
         logprobs = choice.logprobs["content"]
-        return [ChatCompletionTokenLogprob(**logprob) for logprob in logprobs]
+        return logprobs
 
     def format_logprobs_for_cascade(self, logprobs: list[list[ChatCompletionTokenLogprob]]) -> LogprobsForCascade:
         all_tokens = []


### PR DESCRIPTION
When we upgraded the `litellm` version in #181 it introduced a bug when getting the model logprobs, since the output types changed. Prevents the error below seen on main.
```
lotus/models/lm.py:278: in _get_top_choice_logprobs
    return [ChatCompletionTokenLogprob(**logprob) for logprob in logprobs]
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

.0 = <list_iterator object at 0x7fa36c385f60>

>   return [ChatCompletionTokenLogprob(**logprob) for logprob in logprobs]
E   TypeError: litellm.types.utils.ChatCompletionTokenLogprob() argument after ** must be a mapping, not ChatCompletionTokenLogpr
```