### PR TITLE
Support zero-shot CoT for filter

### DIFF
--- a/lotus/sem_ops/postprocessors.py
+++ b/lotus/sem_ops/postprocessors.py
@@ -106,35 +106,6 @@ def get_cot_postprocessor(model: lotus.models.LM, for_extract: bool = False) -> 
     return cot_postprocessor
 
 
-def map_postprocess_cot(llm_answers: list[str]) -> SemanticMapPostprocessOutput:
-    """
-    Postprocess the output of the map operator with CoT reasoning.
-
-    Args:
-        llm_answers (list[str]): The list of llm answers.
-
-    Returns:
-        SemanticMapPostprocessOutput
-    """
-    outputs: list[str] = []
-    explanations: list[str | None] = []
-
-    for llm_answer in llm_answers:
-        reasoning_idx = llm_answer.find("Reasoning:\n")
-        if reasoning_idx == -1:
-            reasoning_idx = 0
-        else:
-            reasoning_idx += len("Reasoning:\n")
-
-        answer_idx = llm_answer.find("Answer:")
-        reasoning = llm_answer[reasoning_idx:answer_idx].rstrip("\n").lstrip("\n")
-        answer = llm_answer[answer_idx + len("Answer:") :]
-        outputs.append(answer)
-        explanations.append(reasoning)
-
-    return SemanticMapPostprocessOutput(raw_outputs=llm_answers, outputs=outputs, explanations=explanations)
-
-
 def map_postprocess(
     llm_answers: list[str],
     model: lotus.models.LM,

--- a/lotus/templates/task_instructions.py
+++ b/lotus/templates/task_instructions.py
@@ -104,6 +104,10 @@ def filter_formatter(
         sys_instruction += cot_prompt_formatter(
             reasoning_instructions=reasoning_instructions, answer_instructions=answer_instructions
         )
+    elif strategy == ReasoningStrategy.ZS_COT:
+        sys_instruction += cot_prompt_formatter(
+            reasoning_instructions=reasoning_instructions, answer_instructions=answer_instructions
+        )
     else:
         sys_instruction += non_cot_prompt_formatter(answer_instructions=answer_instructions)
 
@@ -131,7 +135,7 @@ def filter_formatter(
             # reasoning as filler if the user wants cot reasoning
             if cot_reasoning:
                 content = cot_formatter(cot_reasoning[idx], str(ex_ans))
-            elif strategy == "cot":
+            elif strategy == ReasoningStrategy.COT:
                 content = cot_formatter("Reasoning omitted", str(ex_ans))
             else:
                 content = answer_only_formatter(str(ex_ans))


### PR DESCRIPTION
Addresses #194. I think the CoT code has become very convoluted and there is probably a simpler way to achieve the desired functionality.

```py
import lotus
from lotus.models import LM
from lotus.types import ReasoningStrategy
import pandas as pd

lm = LM(model="gpt-4.1")
lotus.settings.configure(lm=lm)

data = {
    "Text": [
        "I had two apples, then I gave away one",
        "My friend gave me an apple",
        "I gave away both of my apples",
        "I gave away my apple, then a friend gave me his apple, then I threw my apple away",
    ]
}
df = pd.DataFrame(data)
user_instruction = "{Text} I have at least one apple"
filtered_df = df.sem_filter(
    user_instruction, strategy=ReasoningStrategy.ZS_COT, return_all=True, return_explanations=True
) 

print(filtered_df)

```
```txt
Filtering: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████ 4/4 LM calls [00:03<00:00,  1.17it/s]
                                                Text  filter_label                                 explanation_filter
0             I had two apples, then I gave away one          True  The text states, "I had two apples, then I gav...
1                         My friend gave me an apple          True  The text states, "My friend gave me an apple."...
2                      I gave away both of my apples         False  The text states, "I gave away both of my apple...
3  I gave away my apple, then a friend gave me hi...         False  Let's break down the sequence of events:\n1. "...
```