### PR TITLE
Fix duplicate index creation in sem_join

### DIFF
--- a/lotus/sem_ops/sem_join.py
+++ b/lotus/sem_ops/sem_join.py
@@ -355,7 +355,7 @@ def run_sem_sim_join(l1: pd.Series, l2: pd.Series, col1_label: str, col2_label: 
         lotus.logger.error("l1 must be a pandas Series or DataFrame")
 
     l2_df = l2.to_frame(name=col2_label)
-    l2_df = l2_df.sem_index(col2_label, f"{col2_label}_index")
+    l2_df = l2_df.sem_index(col2_label)  # create cache
 
     K = len(l2)
     # Run sem_sim_join as helper on the sampled data

--- a/tests/test_index_cache.py
+++ b/tests/test_index_cache.py
@@ -1,0 +1,109 @@
+import shutil
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+import lotus
+from lotus.models import SentenceTransformersRM
+from lotus.vector_store import FaissVS
+from tests.base_test import BaseTest
+
+# Set logger level to DEBUG
+lotus.logger.setLevel("DEBUG")
+
+
+@pytest.fixture(scope="module")
+def vs():
+    return FaissVS()
+
+
+@pytest.fixture(scope="module")
+def rm():
+    return SentenceTransformersRM(model="sentence-transformers/all-MiniLM-L6-v2")
+
+
+@pytest.fixture
+def sample_df():
+    """
+    Sample DataFrame for testing
+    """
+    return pd.DataFrame({"category": ["Sports", "Food", "Video Games", "STEM"]})
+
+
+@pytest.fixture
+def sample_df_2():
+    """
+    Second different DataFrame for additional testing
+    """
+    return pd.DataFrame({"category": ["Sports", "STEM"]})
+
+
+class TestIndexCache(BaseTest):
+    """Test suite for index caching functionality"""
+
+    @pytest.fixture(autouse=True)
+    def setup_vs(self, rm, vs):
+        lotus.settings.configure(rm=rm, vs=vs)
+
+    def test_backwards_compatibility(self, sample_df, sample_df_2):
+        """
+        Test backward compatibility where the index directory is passed
+        """
+        df1 = sample_df.copy()
+        df2 = sample_df_2.copy()
+
+        df_indexed = df1.sem_index("category", index_dir="custom_index_name")
+        df_indexed_smart = df2.sem_index("category")
+
+        dir_one = df_indexed.attrs["index_dirs"]["category"]
+        dir_two = df_indexed_smart.attrs["index_dirs"]["category"]
+
+        assert "/.cache/lotus/indices/" not in dir_one
+        assert dir_one == "custom_index_name"
+        assert Path(dir_one).exists()
+        assert dir_one != dir_two
+
+        # delete added path
+        if Path("custom_index_name").exists():
+            shutil.rmtree("custom_index_name")
+
+    def test_cache_directory_location(self, sample_df):
+        """Test that cache is created in ~/.cache/lotus/indices/"""
+        df = sample_df.copy()
+        df_indexed = df.sem_index("category")
+
+        cache_dir = df_indexed.attrs["index_dirs"]["category"]
+        assert "/.cache/lotus/indices/" in cache_dir
+
+    def test_cache_files_exist(self, sample_df):
+        """
+        Test that cache creates both 'index' and 'vecs' files (FAISS creates this)
+        """
+        df = sample_df.copy()
+        df_indexed = df.sem_index("category")
+        cache_dir = df_indexed.attrs["index_dirs"]["category"]
+
+        assert Path(cache_dir).exists()
+        assert (Path(cache_dir) / "index").exists()
+        assert (Path(cache_dir) / "vecs").exists()
+
+    def test_dir_name(self, sample_df, sample_df_2):
+        """
+        Test that calling sem_index twice with same data reuses the cache, while
+        different data uses different caches
+        """
+        # same data should give same dir
+        df1 = sample_df.copy()
+        df2 = sample_df.copy()
+        df3 = sample_df_2.copy()
+
+        # get the dir
+        first_cache_dir = df1.sem_index("category").attrs["index_dirs"]["category"]
+        second_cache_dir = df2.sem_index("category").attrs["index_dirs"]["category"]
+        third_cache_dir = df3.sem_index("category").attrs["index_dirs"]["category"]
+
+        # same data has same directory, different data does not
+        assert first_cache_dir == second_cache_dir
+        assert first_cache_dir != third_cache_dir
+        assert second_cache_dir != third_cache_dir


### PR DESCRIPTION
## Purpose

The purpose of this PR is to fix the duplicated index and inefficiency, addressing [Issue #70](https://github.com/lotus-data/lotus/issues/70)

- Added utility function in utils.py which gets cache path for semantic index and reuses the index if the data has not changed
- Improved logic inside of sem_index.py to enable the user to specify the index directory or let my helper function create a directory in the cache
- Updated the function call to sem_index inside of sem_join.py to ensure double index creations are not made and the cache is being hit

## Test Plan

Created four test cases to ensure full functionality and of the code. The first test case, test_backwards_compatibility, ensures backwards compatibility in the code where the index_dir parameter still works as before, creating indices in the specified directory rather than the cache. The next tests test the caching functionality where test_cache_directory_location tests cache paths are created in ~/.cache/lotus/indices/, test_cache_files_exist checks that FAISS index and vec files are created in the cache directory, and finally the last test test_dir_name tests the caching logic where identical data produces identical cache paths due to the same SHA256 hash whereas different data produces different paths as expected.

Here are the commands inside of tests/test_index_cache.py that have been added and their expected inputs and outcomes:

- test_backwards_compatibility(self, sample_df, sample_df_2): Test backward compatibility where the index directory is passed.
- test_cache_directory_location(self, sample_df): Test that cache is created in ~/.cache/lotus/indices/
- test_cache_files_exist(self, sample_df): Test that cache creates both 'index' and 'vecs' files.
- test_dir_name(self, sample_df, sample_df_2): Test that calling sem_index twice with same data reuses the cache, while
                                                                          different data uses different caches.

## Test Results

All four added tests inside of test_index_cache.py passed locally, confirming correct caching behavior for sem_index.

## Documentation Update

The documentation for sem_index may need updates as now my PR eliminates the need for explicitly passing in an index directory.

## Type of Change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, updating docstrings
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes

<!--- pyml disable-next-line no-emphasis-as-heading -->
**BEFORE SUBMITTING, PLEASE READ <https://github.com/lotus-data/lotus/blob/main/CONTRIBUTING.md>** 
anything written below this line will be removed by GitHub Actions