### PR TITLE
add max_completion_token param for gpt5 models

### DIFF
--- a/tests/test_lm.py
+++ b/tests/test_lm.py
@@ -271,17 +271,16 @@ class TestLM(BaseTest):
             second_call_args = mock_batch_completion.call_args_list[1]
             assert len(second_call_args[0][1]) == 10  # Second argument is the batch
 
-    def test_max_tokens_parameter_flexibility(self):
-        """Test that the LM handles token parameters dynamically without hardcoding model names.
+    def test_max_tokens_parameter_uses_max_completion_tokens(self):
+        """Test that the LM uses max_completion_tokens for all models.
 
-        The LM class starts with max_tokens (most common) and automatically retries with
-        max_completion_tokens if the API rejects the request. This approach eliminates
-        the need to maintain model-specific parameter mappings.
+        LiteLLM automatically translates max_completion_tokens to max_tokens for older models
+        that don't support it, so we can use max_completion_tokens universally without needing
+        model-specific logic.
         """
-        # All models start with max_tokens by default
+        # All models use max_completion_tokens - LiteLLM handles translation
         for model_name in ["gpt-4o-mini", "gpt-5", "o3-mini", "claude-3-opus"]:
             lm = LM(model=model_name, max_tokens=100)
-            # Initially set to max_tokens
-            assert "max_tokens" in lm.kwargs
-            assert lm.kwargs["max_tokens"] == 100
-            # If API rejects it, the try-catch in batch_completion calls handles the retry
+            assert "max_completion_tokens" in lm.kwargs
+            assert lm.kwargs["max_completion_tokens"] == 100
+            assert "max_tokens" not in lm.kwargs


### PR DESCRIPTION
## Essential Elements of an Effective PR Description Checklist
- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `README.md` and `examples` for new features.

PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS ABOVE HAVE BEEN CONSIDERED.

## Purpose

GPT-5 and GPT-5 like models do not have a max_token param, PR resolves #221 handling max_token param when gpt 5 models are used. Switches to using max_completion_token param using Litellm. https://docs.litellm.ai/docs/completion/input

## Test Plan

Included new test suite within `test_lm.py`

## Test Results

<img width="466" height="140" alt="Screenshot 2025-12-05 at 4 35 53 PM" src="https://github.com/user-attachments/assets/e373aa80-b9cb-4878-930f-973c63655b04" />



## (Optional) Documentation Update

<!-- List any documentation files that need to be updated -->

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, updating docstrings
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

<!--- pyml disable-next-line no-emphasis-as-heading -->
**BEFORE SUBMITTING, PLEASE READ <https://github.com/lotus-data/lotus/blob/main/CONTRIBUTING.md>** 
anything written below this line will be removed by GitHub Actions