### PR TITLE
Bump version to 1.2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "lotus-ai"
-version = "1.1.4"
+version = "1.2.0"
 description = "lotus"
 readme = "README.md"
 authors = [


### PR DESCRIPTION
## Purpose

Bump the package version `1.1.4 → 1.2.0` in `pyproject.toml` for the next PyPI release. Minor bump covering the AST-based lazy-evaluation / semantic-operator optimization work landed since 1.1.4.

Only change is the version string.

## Note on CI

The failing checks here are **not** caused by this PR (the diff is one line):
- **Lint/type-check** failure is pre-existing dependency drift — fixed by #254. Once #254 merges, re-running this PR's checks passes via the merge-ref.
- **OpenAI** test jobs fail with `billing_not_active` (429) on the account behind the `OPENAI_API_KEY` secret — unrelated; needs the account's billing fixed / key rotated.

After merge, tag `v1.2.0` on `main` to trigger the publish workflow (#253).

## Type of Change

- [x] Other (release/version bump)
