### PR TITLE
Fix mypy errors from dependency drift (unblock CI)

### DIFF
--- a/lotus/file_extractors/directory_reader.py
+++ b/lotus/file_extractors/directory_reader.py
@@ -296,7 +296,7 @@ class DirectoryReader:
         _file_path = None
         try:
             # Using stream mode to allow large files
-            with requests.get(url, timeout=timeout, stream=True) as response:
+            with requests.get(str(url), timeout=timeout, stream=True) as response:
                 response.raise_for_status()
 
                 # Download initial chunk to determine file type

--- a/lotus/utils.py
+++ b/lotus/utils.py
@@ -59,15 +59,15 @@ def cluster(col_name: str, ncentroids: int) -> Callable[[pd.DataFrame, int, bool
         vec_set = vs.get_vectors_from_index(col_index_dir, ids)
         d = vec_set.shape[1]
         kmeans = faiss.Kmeans(d, ncentroids, niter=niter, verbose=verbose)
-        kmeans.train(vec_set)
+        kmeans.train(vec_set)  # type: ignore[arg-type]
 
         # get nearest centroid to each vector
-        scores, indices = kmeans.index.search(vec_set, 1)
+        scores, indices = kmeans.index.search(vec_set, 1)  # type: ignore[arg-type]
 
         # get the cluster centroids
         # centroids = kmeans.centroids
         # return indices.flatten(), scores.flatten(), centroids
-        return indices.flatten()
+        return indices.flatten()  # type: ignore[return-value]
 
     return ret
 

--- a/lotus/vector_store/faiss_vs.py
+++ b/lotus/vector_store/faiss_vs.py
@@ -21,7 +21,7 @@ class FaissVS(VS):
 
     def index(self, docs: list[str], embeddings: NDArray[np.float64], index_dir: str, **kwargs: dict[str, Any]) -> None:
         self.faiss_index = faiss.index_factory(embeddings.shape[1], self.factory_string, self.metric)
-        self.faiss_index.add(embeddings)
+        self.faiss_index.add(embeddings)  # type: ignore[arg-type]
         self.index_dir = index_dir
 
         os.makedirs(index_dir, exist_ok=True)
@@ -61,10 +61,10 @@ class FaissVS(VS):
             # Create a temporary FAISS index for the subset. This means we assume the same
             # dimensionality, factory, and metric as the main index.
             tmp_index = faiss.index_factory(subset_vecs.shape[1], self.factory_string, self.metric)
-            tmp_index.add(subset_vecs)
+            tmp_index.add(subset_vecs)  # type: ignore[arg-type]
 
             # Perform search on the temporary index.
-            distances, sub_indices = tmp_index.search(query_vectors, K)
+            distances, sub_indices = tmp_index.search(query_vectors, K)  # type: ignore[arg-type]
 
             # Remap the sub-indices to the original global ids.
             # Here we convert the list of filtered ids into a NumPy array so that we can index it.
@@ -72,6 +72,6 @@ class FaissVS(VS):
             indices = np.array([subset_ids[sub_indices[i]] for i in range(len(sub_indices))]).tolist()
         else:
             # Otherwise, search against the entire index.
-            distances, indices = self.faiss_index.search(query_vectors, K)
+            distances, indices = self.faiss_index.search(query_vectors, K)  # type: ignore[arg-type]
 
         return RMOutput(distances=distances, indices=indices)  # type: ignore


### PR DESCRIPTION
## Purpose

Unblock CI. The **Lint and Type Check** job started failing on PRs that change no code at all (e.g. the version bump in #252). Root cause is **dependency drift**: CI installs unpinned dev/runtime deps, and newer `faiss-cpu` type stubs + `mypy` now flag pre-existing imprecision at the faiss float32 boundary. `main` was last green on 2026-04-30 with byte-identical code.

Minimal, behavior-preserving fixes:
- `file_extractors/directory_reader.py`: `requests.get(str(url), ...)` — `url` is `str | Path`.
- `vector_store/faiss_vs.py` / `utils.py`: targeted `# type: ignore[arg-type]` at the faiss `add`/`search`/`Kmeans.train` calls (arrays are float32 at runtime; the stubs are imprecise) and `# type: ignore[return-value]` on `indices.flatten()`.

`mypy.ini` sets neither `strict` nor `warn_unused_ignores`, so the ignores stay safe across future stub changes.

Unblocks #252 and #253 (their lint passes via the PR merge-ref once this lands).

## Test Plan

Reproduced CI exactly in a fresh `.[dev]` venv (Python 3.10, matching the workflow):
```
uv venv .venv-ci -p 3.10 && source .venv-ci/bin/activate
uv pip install -e '.[dev]'
ruff check lotus/
mypy lotus/
```

## Test Results

- Before: `mypy lotus/` → `Found 8 errors in 3 files` (exit 1).
- After: `ruff check lotus/` → `All checks passed!`; `mypy lotus/` → `Success: no issues found in 60 source files` (exit 0).
- The OpenAI-dependent test jobs are out of scope here — they fail with `billing_not_active` (429) on the account behind the `OPENAI_API_KEY` secret, unrelated to this change.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes (ruff + mypy green; runtime tests gated on the unrelated OpenAI billing issue)
