### PR TITLE
Fix PyPI publish: use gepa from PyPI instead of git URL

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,7 +80,7 @@ dev = [
     "pre-commit>=4.0.1",
 ]
 gepa = [
-    "gepa @ git+https://github.com/gepa-ai/gepa.git"
+    "gepa>=0.1.1"
 ]
 
 [tool.hatch.metadata]


### PR DESCRIPTION
PyPI rejects direct-URL dependencies, which blocked the v1.2.0 upload:

```
400 Bad Request: Can't have direct dependency: gepa @ git+https://github.com/gepa-ai/gepa.git ; extra == "gepa"
```

`gepa` is published on PyPI (latest 0.1.1), so reference it normally in the optional `gepa` extra instead of the git URL.

**Verified:** built the wheel with `uv build`; METADATA now reads `Requires-Dist: gepa>=0.1.1; extra == 'gepa'` with no direct git reference. Nothing was published for 1.2.0 (the upload failed on the first file), so re-tagging republishes cleanly.