### PR TITLE
Fix pairwise_judge GEPA helper-instruction tests (A/B placeholders)

### DIFF
--- a/lotus/ast/nodes.py
+++ b/lotus/ast/nodes.py
@@ -999,10 +999,14 @@ class PairwiseJudgeNode(BaseNode):
     model_kwargs: dict[str, Any] | None = None
 
     def _effective_sem_filter_user_instruction(self) -> str:
-        renamed_instr = self.judge_instruction.replace(f"{{{self.col1}}}", "{col_A}").replace(
-            f"{{{self.col2}}}", "{col_B}"
+        # Mirror the runtime pairwise_judge cascade, which renames the two
+        # columns to single-token "A"/"B" (see evals/pairwise_judge.py
+        # _unique_col_names). Single tokens are required for the cascade —
+        # "col_A"/"col_B" tokenize to 2 tokens and break it (see #248).
+        renamed_instr = self.judge_instruction.replace(f"{{{self.col1}}}", "{A}").replace(
+            f"{{{self.col2}}}", "{B}"
         )
-        return f"{{col_A}} is better than {{col_B}} given the criteria: {renamed_instr}"
+        return f"{{A}} is better than {{B}} given the criteria: {renamed_instr}"
 
     def supports_optimizable_param(self, param_name: str) -> bool:
         if param_name == self._HELPER_FILTER_INSTRUCTION_PARAM:

--- a/lotus/ast/optimizer/gepa_optimizer.py
+++ b/lotus/ast/optimizer/gepa_optimizer.py
@@ -256,8 +256,8 @@ class GEPAOptimizer(BaseOptimizer):
     ``join_instruction`` on sem_join, and ``query`` on sem_search are optimized.
     For sem_filter cascades that use ``HELPER_LM``, the helper prompt target
     ``cascade_args.helper_filter_instruction`` is also optimized.
-    The same helper prompt target is exposed for ``pairwise_judge`` nodes in
-    ``mode="sem_filter"`` when using helper-LM cascades.
+    The same helper prompt target is exposed for ``pairwise_judge`` nodes
+    when using helper-LM cascades (pairwise_judge runs on a sem_filter cascade).
     Use ``mark_optimizable`` on the ``LazyFrame`` to customize which parameters
     to optimize or to exclude specific nodes entirely.
 

--- a/lotus/evals/pairwise_judge.py
+++ b/lotus/evals/pairwise_judge.py
@@ -53,15 +53,15 @@ class PairwiseJudgeDataframe:
             estimation. Defaults to False.
         progress_bar_desc (str, optional): Description for the progress bar.
             Defaults to "Evaluating".
-        default_to_col1 (bool, optional): [sem_filter mode only] The default filter decision when
+        default_to_col1 (bool, optional): The default filter decision when
             the model is uncertain. Defaults to True.
-        helper_examples (pd.DataFrame | None, optional): [sem_filter mode only] Example
+        helper_examples (pd.DataFrame | None, optional): Example
             DataFrame for the helper LM in cascade filtering. Defaults to None.
-        cascade_args (CascadeArgs | None, optional): [sem_filter mode only] Arguments for
+        cascade_args (CascadeArgs | None, optional): Arguments for
             cascade filtering to reduce cost via a proxy model. Defaults to None.
-        return_stats (bool, optional): [sem_filter mode only] Whether to return a stats
+        return_stats (bool, optional): Whether to return a stats
             dict alongside the DataFrame as a (DataFrame, stats) tuple. Defaults to False.
-        additional_cot_instructions (str, optional): [sem_filter mode only] Extra
+        additional_cot_instructions (str, optional): Extra
             instructions appended to the chain-of-thought prompt. Defaults to "".
         **model_kwargs: Any: Additional keyword arguments to pass to the model.
 

--- a/tests/test_gepa_optimizer.py
+++ b/tests/test_gepa_optimizer.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import json
 import os
-from typing import Any, Literal, cast
+from typing import Any, cast
 
 import pandas as pd
 import pytest
@@ -72,14 +72,12 @@ def _make_shared_assign_lf() -> LazyFrame:
 def _make_pairwise_sem_filter_lf(
     helper_instruction: str | None = None,
     *,
-    mode: Literal["llm_as_judge", "sem_filter"] = "sem_filter",
     proxy_model: ProxyModel = ProxyModel.HELPER_LM,
 ) -> LazyFrame:
     return LazyFrame().pairwise_judge(
         col1="answer_a",
         col2="answer_b",
         judge_instruction="Prefer better answer for {question}",
-        mode=mode,
         cascade_args=CascadeArgs(
             proxy_model=proxy_model,
             helper_filter_instruction=helper_instruction,
@@ -197,8 +195,9 @@ class TestCollectTargets:
         lf = _make_pairwise_sem_filter_lf()
         targets = self.opt._collect_targets(lf._nodes)
         helper_target = next(t for t in targets if t.param_name == "cascade_args.helper_filter_instruction")
+        # Mirrors the runtime cascade which renames cols to single-token A/B.
         assert helper_target.value == (
-            "{answer_a} is better than {answer_b} given the criteria: Prefer better answer for {question}"
+            "{A} is better than {B} given the criteria: Prefer better answer for {question}"
         )
 
     def test_pairwise_helper_instruction_target_uses_explicit_override(self) -> None:
@@ -207,14 +206,12 @@ class TestCollectTargets:
         helper_target = next(t for t in targets if t.param_name == "cascade_args.helper_filter_instruction")
         assert helper_target.value == "{answer_a} is safer than {answer_b}"
 
-    def test_pairwise_helper_instruction_target_not_enabled_for_non_helper_cases(self) -> None:
+    def test_pairwise_helper_instruction_target_not_enabled_for_embedding_proxy(self) -> None:
+        # Embedding-proxy cascades rank by similarity, not a helper instruction,
+        # so there is no helper_filter_instruction to optimize.
         lf_embedding = _make_pairwise_sem_filter_lf(proxy_model=ProxyModel.EMBEDDING_MODEL)
         targets_embedding = self.opt._collect_targets(lf_embedding._nodes)
         assert all(t.param_name != "cascade_args.helper_filter_instruction" for t in targets_embedding)
-
-        lf_llm_as_judge = _make_pairwise_sem_filter_lf(mode="llm_as_judge")
-        targets_llm_as_judge = self.opt._collect_targets(lf_llm_as_judge._nodes)
-        assert all(t.param_name != "cascade_args.helper_filter_instruction" for t in targets_llm_as_judge)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Purpose

Fix the two failing `tests/test_gepa_optimizer.py::TestCollectTargets` pairwise tests. These tests aren't run in CI (the workflow installs `.[dev]`, not the `gepa` extra), so they silently bitrotted.

**1. Placeholder drift (`{col_A}/{col_B}` → `{A}/{B}`).** `PairwiseJudgeNode._effective_sem_filter_user_instruction` emitted `{col_A}/{col_B}`, but the runtime `pairwise_judge` cascade renames the two columns to single-token `A`/`B` (`evals/pairwise_judge.py` `_unique_col_names`). `col_A`/`col_B` tokenize to 2 tokens and break the cascade — exactly what #248 fixed in the runtime; the AST node was missed. Aligned the node to `{A}/{B}`.

**2. Obsolete `mode="llm_as_judge"` assertion.** The second test asserted behavior for a pairwise_judge `mode` that does not exist anywhere (runtime, `LazyFrame`, or node) — pairwise_judge is intentionally always a `sem_filter` cascade since #246, and the `mode=` kwarg was silently swallowed into `**model_kwargs`. Dropped the obsolete sub-assertion (renamed the test to `..._for_embedding_proxy`, the real remaining no-helper case) and removed the dead `mode` plumbing from the test helper.

Also scrubbed the misleading `[sem_filter mode only]` docstring tags in `pairwise_judge.py` and the `mode="sem_filter"` reference in the GEPA optimizer docstring (there is no other mode).

## Test Plan

Fresh `.[dev,gepa]` venv (gepa 0.1.1 from PyPI), Python 3.10:
```
uv pip install -e '.[dev,gepa]'
python -m pytest tests/test_gepa_optimizer.py -q
ruff check lotus/ tests/test_gepa_optimizer.py
```

## Test Results

- Before: `2 failed, 25 passed, 1 skipped`.
- After: **`27 passed, 1 skipped`** (the skip is `test_gepa_optimizer_end_to_end`, which needs an API key); `ruff` clean.
- CI's "Lint and Type Check" (mypy on `.[dev]`, no `gepa`) is unaffected — the only changed runtime line is a string literal in `nodes.py`; the rest are docstrings/tests.

## Type of Change

- [x] Bug fix (non-breaking)
