### PR TITLE
Bump version to 1.2.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "lotus-ai"
-version = "1.2.0"
+version = "1.2.1"
 description = "lotus"
 readme = "README.md"
 authors = [


### PR DESCRIPTION
Patch release. Bumps `pyproject.toml` 1.2.0 → 1.2.1.

Includes the pairwise_judge GEPA helper-instruction A/B fix from #257 (corrects the AST `PairwiseJudgeNode` to emit single-token `{A}/{B}` matching the runtime sem_filter cascade; `col_A`/`col_B` tokenize to 2 tokens and break the cascade).

After merge, tag `v1.2.1` on main to trigger the publish workflow (#253).