### PR TITLE
Fix gpt-5/reasoning-model accuracy: model-aware max_tokens default

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -51,7 +51,7 @@ jobs:
         test-suite: [settings, lm-openai, lm-ollama, rm, multimodality, utility_operators, cache]
         include:
           - test-suite: settings
-            file: tests/test_settings.py
+            file: tests/test_settings.py tests/test_lm_defaults.py
             timeout: 5
           - test-suite: lm-openai
             file: .github/tests/lm_tests.py

--- a/lotus/models/lm.py
+++ b/lotus/models/lm.py
@@ -505,16 +505,20 @@ class LM:
         choice = response.choices[0]
         assert isinstance(choice, Choices)
         if choice.finish_reason == "length":
+            fix_hint = (
+                f"Raise the budget when configuring the model, e.g.: "
+                f'lotus.settings.configure(lm=LM(model="{self.model}", max_tokens={self.max_tokens * 2}))'
+            )
             lotus.logger.warning(
                 f"Completion from {self.model} was truncated by the max_tokens limit "
                 f"({self.max_tokens}). "
                 + (
                     "This is a reasoning model: hidden reasoning tokens are spent from the same "
                     "budget, so an exhausted budget can return an empty answer that operators "
-                    "silently coerce to their default output. Raise max_tokens or lower "
-                    "reasoning_effort."
+                    f"silently coerce to their default output. {fix_hint}, or lower the "
+                    'reasoning depth with LM(..., reasoning_effort="minimal").'
                     if self.is_reasoning_model()
-                    else "Consider raising max_tokens."
+                    else f"{fix_hint}."
                 )
             )
         if choice.message.content is None:

--- a/lotus/models/lm.py
+++ b/lotus/models/lm.py
@@ -10,7 +10,7 @@ import numpy as np
 from litellm import batch_completion
 from litellm.exceptions import AuthenticationError
 from litellm.types.utils import ChatCompletionTokenLogprob, ChoiceLogprobs, Choices, ModelResponse
-from litellm.utils import decode, encode, token_counter
+from litellm.utils import decode, encode, supports_reasoning, token_counter
 from openai._exceptions import OpenAIError
 from pydantic import BaseModel
 from tokenizers import Tokenizer
@@ -36,6 +36,15 @@ logging.getLogger("httpx").setLevel(logging.CRITICAL)
 # This is a known upstream litellm issue and the warnings are harmless — the values
 # are still serialized correctly.
 warnings.filterwarnings("ignore", message="Pydantic serializer warnings", category=UserWarning, module="pydantic.*")
+
+# Default completion-token budgets. Reasoning models (gpt-5, o-series, ...) spend
+# hidden reasoning tokens from the same max_completion_tokens budget as the visible
+# answer, so they need a much larger default: with the standard 512-token budget a
+# reasoning model can exhaust the entire budget before emitting any visible text,
+# returning an empty completion that operators silently coerce to their default
+# output (see issue #255).
+DEFAULT_MAX_TOKENS = 512
+DEFAULT_REASONING_MAX_TOKENS = 8192
 
 
 class LM:
@@ -69,7 +78,7 @@ class LM:
         model: str = "gpt-4o-mini",
         temperature: float = 0.0,
         max_ctx_len: int = 128000,
-        max_tokens: int = 512,
+        max_tokens: int | None = None,
         max_batch_size: int = 64,
         rate_limit: int | None = None,
         tpm_limit: int | None = None,
@@ -86,7 +95,11 @@ class LM:
             model (str): Name of the model to use. Defaults to "gpt-4o-mini".
             temperature (float): Sampling temperature. Defaults to 0.0.
             max_ctx_len (int): Maximum context length in tokens. Defaults to 128000.
-            max_tokens (int): Maximum number of tokens to generate. Defaults to 512.
+            max_tokens (int | None): Maximum number of completion tokens. Defaults to
+                512, or 8192 for reasoning models (gpt-5, o-series, ...), whose hidden
+                reasoning tokens are spent from this same budget. Set explicitly to
+                override; pass reasoning_effort (e.g. "minimal") via kwargs to trade
+                reasoning depth for cost on supported models.
             max_batch_size (int): Maximum batch size for concurrent requests. Defaults to 64.
             rate_limit (int | None): Maximum requests per minute. If set, caps max_batch_size and adds delays.
             tokenizer (Tokenizer | None): Custom tokenizer instance. Defaults to None.
@@ -97,6 +110,8 @@ class LM:
         """
         self.model = model
         self.max_ctx_len = max_ctx_len
+        if max_tokens is None:
+            max_tokens = DEFAULT_REASONING_MAX_TOKENS if self.is_reasoning_model() else DEFAULT_MAX_TOKENS
         self.max_tokens = max_tokens
         self.rate_limit = rate_limit
         self.tpm_limit = tpm_limit
@@ -489,6 +504,19 @@ class LM:
 
         choice = response.choices[0]
         assert isinstance(choice, Choices)
+        if choice.finish_reason == "length":
+            lotus.logger.warning(
+                f"Completion from {self.model} was truncated by the max_tokens limit "
+                f"({self.max_tokens}). "
+                + (
+                    "This is a reasoning model: hidden reasoning tokens are spent from the same "
+                    "budget, so an exhausted budget can return an empty answer that operators "
+                    "silently coerce to their default output. Raise max_tokens or lower "
+                    "reasoning_effort."
+                    if self.is_reasoning_model()
+                    else "Consider raising max_tokens."
+                )
+            )
         if choice.message.content is None:
             raise ValueError(f"No content in response: {response}")
         return choice.message.content
@@ -612,3 +640,12 @@ class LM:
     def is_deepseek(self) -> bool:
         model_name = self.get_model_name()
         return model_name.startswith("deepseek-r1")
+
+    def is_reasoning_model(self) -> bool:
+        """Whether the model spends hidden reasoning tokens from the completion budget
+        (e.g. gpt-5 and the o-series)."""
+        try:
+            return supports_reasoning(model=self.model)
+        except Exception:
+            # Unknown/unmapped models: assume non-reasoning.
+            return False

--- a/tests/test_lm_defaults.py
+++ b/tests/test_lm_defaults.py
@@ -51,3 +51,34 @@ def test_unknown_model_falls_back_to_standard_default():
 def test_reasoning_detection():
     assert LM(model="gpt-5").is_reasoning_model()
     assert not LM(model="gpt-4o-mini").is_reasoning_model()
+
+
+def test_truncation_warning_includes_configure_hint(caplog):
+    import logging
+
+    from litellm.types.utils import ModelResponse
+
+    lm = LM(model="gpt-5", max_tokens=64)
+    truncated = ModelResponse(
+        choices=[{"finish_reason": "length", "message": {"role": "assistant", "content": ""}}]
+    )
+    with caplog.at_level(logging.WARNING, logger="lotus"):
+        assert lm._get_top_choice(truncated) == ""
+    assert "truncated by the max_tokens limit (64)" in caplog.text
+    # The warning must tell users exactly how to fix it via the settings API.
+    assert 'lotus.settings.configure(lm=LM(model="gpt-5", max_tokens=128))' in caplog.text
+    assert 'reasoning_effort="minimal"' in caplog.text
+
+
+def test_truncation_warning_standard_model(caplog):
+    import logging
+
+    from litellm.types.utils import ModelResponse
+
+    lm = LM(model="gpt-4o-mini", max_tokens=64)
+    truncated = ModelResponse(
+        choices=[{"finish_reason": "length", "message": {"role": "assistant", "content": "partial"}}]
+    )
+    with caplog.at_level(logging.WARNING, logger="lotus"):
+        assert lm._get_top_choice(truncated) == "partial"
+    assert 'lotus.settings.configure(lm=LM(model="gpt-4o-mini", max_tokens=128))' in caplog.text

--- a/tests/test_lm_defaults.py
+++ b/tests/test_lm_defaults.py
@@ -1,0 +1,53 @@
+"""Offline tests for LM default completion-token budgets (issue #255).
+
+Reasoning models (gpt-5, o-series) spend hidden reasoning tokens from the same
+max_completion_tokens budget as the visible answer. With the old flat 512
+default, gpt-5 could exhaust the budget before emitting any visible text;
+sem_filter then silently coerced the empty answer to default=True for every
+affected row. These tests pin the model-aware defaults without making any API
+calls.
+"""
+
+from lotus.models import LM
+from lotus.models.lm import DEFAULT_MAX_TOKENS, DEFAULT_REASONING_MAX_TOKENS
+
+
+def test_standard_model_keeps_512_default():
+    lm = LM(model="gpt-4o-mini")
+    assert lm.max_tokens == DEFAULT_MAX_TOKENS
+    assert lm.kwargs["max_completion_tokens"] == DEFAULT_MAX_TOKENS
+
+
+def test_reasoning_model_gets_larger_default():
+    lm = LM(model="gpt-5")
+    assert lm.max_tokens == DEFAULT_REASONING_MAX_TOKENS
+    assert lm.kwargs["max_completion_tokens"] == DEFAULT_REASONING_MAX_TOKENS
+
+
+def test_o_series_detected_as_reasoning():
+    lm = LM(model="o3")
+    assert lm.is_reasoning_model()
+    assert lm.max_tokens == DEFAULT_REASONING_MAX_TOKENS
+
+
+def test_explicit_max_tokens_wins_on_reasoning_model():
+    lm = LM(model="gpt-5", max_tokens=1000)
+    assert lm.max_tokens == 1000
+    assert lm.kwargs["max_completion_tokens"] == 1000
+
+
+def test_explicit_max_tokens_wins_on_standard_model():
+    lm = LM(model="gpt-4o-mini", max_tokens=1024)
+    assert lm.max_tokens == 1024
+    assert lm.kwargs["max_completion_tokens"] == 1024
+
+
+def test_unknown_model_falls_back_to_standard_default():
+    lm = LM(model="totally-unknown-model-xyz")
+    assert not lm.is_reasoning_model()
+    assert lm.max_tokens == DEFAULT_MAX_TOKENS
+
+
+def test_reasoning_detection():
+    assert LM(model="gpt-5").is_reasoning_model()
+    assert not LM(model="gpt-4o-mini").is_reasoning_model()


### PR DESCRIPTION
Fixes #255.

## Root cause

Reasoning models (gpt-5, o-series) spend **hidden reasoning tokens from the same `max_completion_tokens` budget** as the visible answer. Lotus's flat `max_tokens=512` default starves them:

1. On non-trivial rows, gpt-5 burns the entire 512-token budget on internal reasoning (`finish_reason='length'`)
2. The completion comes back with `content=''` (or OpenAI 400s with *"Could not finish the message because max_tokens or model output limit was reached"*)
3. `filter_postprocess` finds neither output token in the empty string and **silently coerces the row to `default=True`** — bad accuracy, zero errors

## Empirical confirmation (debug branch `debug-gpt5-repro`, runs in Actions)

| Scenario | reasoning tokens | result |
|---|---|---|
| trivial sentiment claim @512 | 64 | `Answer: True` ✓ (8/8 — easy tasks unaffected) |
| hard arithmetic claim @512 | 448–512 | one row empty → defaulted → **5/6** |
| same, @8000 budget | ~512 | **6/6** |
| hard ZS_COT @512 | — | truncated/empty rows → **5/6** |
| forced 64-token budget | 64 | `finish_reason=length`, `content=''`, sometimes OpenAI 400 |
| gpt-4o-mini @512 (control) | 0 | **6/6** |

On real workloads (longer docs, harder predicates) most rows blow the 512 budget, which is why gpt-5 looked uniformly broken.

## Fix

- `LM` default `max_tokens` is now model-aware: **8192 for reasoning models** (detected via `litellm.supports_reasoning`), 512 otherwise. An explicit `max_tokens` always wins. `max_completion_tokens` is a cap, not a purchase — this only affects worst-case per-row cost on reasoning models.
- `_get_top_choice` now **warns on `finish_reason='length'`** with a reasoning-model-specific hint, so this failure mode is never silent again.
- Users can still pass `reasoning_effort="minimal"` (forwarded via kwargs) to trade reasoning depth for cost — verified working in the probes.

## Tests

- New offline `tests/test_lm_defaults.py` (7 tests, no API calls) pinning the model-aware defaults; wired into the `settings` CI suite.
- End-to-end verification run on the debug branch: gpt-5 with pure library defaults on the previously-failing hard set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)