### PR TITLE
Fix flaky test_pairwise_judge (ambiguous row removed)

### DIFF
--- a/.github/tests/lm_tests.py
+++ b/.github/tests/lm_tests.py
@@ -694,15 +694,15 @@ def test_pairwise_judge(setup_models, model):
     data = {
         "instruction": [
             "Write a one-sentence summary of the benefits of regular exercise.",
-            "Suggest a polite email subject line to schedule a 1:1 meeting.",
+            "Suggest a polite, professional email subject line to schedule a 1:1 meeting.",
         ],
         "model_a": [
             "Regular exercise improves physical health and mental well-being by boosting energy, mood, and resilience.",
-            "Meeting request.",
+            "ayo lets meet",
         ],
         "model_b": [
             "Exercise is good.",
-            "Requesting a 1:1: finding time to connect next week?",
+            "Request to schedule a brief 1:1 meeting at your convenience",
         ],
     }
     df = pd.DataFrame(data)


### PR DESCRIPTION
## Problem

`test_pairwise_judge[gpt-4o-mini]` failed intermittently — **3 spurious `lm-openai` failures in a single day**, each passing on rerun. Always the same assertion:

```
assert list(df["_judge_0"].values) == ["A", "B"]
E  AssertionError: assert ['A', 'A'] == ['A', 'B']
```

Row 1 of the fixture was genuinely ambiguous:

| instruction | model_a | model_b | expected |
|---|---|---|---|
| "polite email subject line to schedule a 1:1" | `"Meeting request."` | `"Requesting a 1:1: finding time to connect next week?"` | B |

`"Meeting request."` is a perfectly acceptable subject line, so the judge legitimately preferred it part of the time → non-deterministic verdict → flaky test.

## Fix

Make row 1 have a clear winner, the way row 0 already does (a strong summary vs `"Exercise is good."`):

- **model_a**: `"ayo lets meet"` — casual, unprofessional
- **model_b**: `"Request to schedule a brief 1:1 meeting at your convenience"` — polite, professional

The expected verdict (B better) is now unambiguous, so the exact A/B assertion is stable. No production code changed.