### PR TITLE
Bump version to 1.2.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "lotus-ai"
-version = "1.2.1"
+version = "1.2.2"
 description = "lotus"
 readme = "README.md"
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -1366,7 +1366,7 @@ wheels = [
 
 [[package]]
 name = "lotus-ai"
-version = "1.2.1"
+version = "1.2.2"
 source = { editable = "." }
 dependencies = [
     { name = "backoff" },


### PR DESCRIPTION
Release **v1.2.2**. Bumps `pyproject.toml` 1.2.1 → 1.2.2 and regenerates `uv.lock` to match (so the locked-constraints CI step stays green).

Notable changes shipping in this release since 1.2.1:
- **#260** — gpt-5 / reasoning-model accuracy fix: model-aware `max_tokens` default + truncation warning (closes #255)
- **#262** — fix flaky `test_pairwise_judge`
- **#261** — consolidate duplicate benchmark directories
- **#219** — Biodex + reranking benchmark suites (resolves #227)

On merge I'll tag `v1.2.2` off `main`, which triggers `publish.yml` to build and publish to PyPI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)