### PR TITLE
docs: rename Evaluation Suite to LLM Judge Suite; reorder + retitle

### DIFF
--- a/docs/evaluation.rst
+++ b/docs/evaluation.rst
@@ -1,5 +1,5 @@
-Evaluation Suite
-================
+Overview
+========
 
 LOTUS includes LLM-as-judge tools for evaluating model outputs, application
 responses, and content quality directly from pandas DataFrames.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -59,17 +59,6 @@ LLM-as-judge evaluation, document extraction, and unstructured data analysis.
 .. toctree::
    :hidden:
    :maxdepth: 1
-   :caption: Utility Operators
-
-   sem_partition
-   sem_index
-   sem_dedup
-   web_search
-   web_extract
-
-.. toctree::
-   :hidden:
-   :maxdepth: 1
    :caption: Optimizations
 
    lazyframe
@@ -79,12 +68,23 @@ LLM-as-judge evaluation, document extraction, and unstructured data analysis.
 .. toctree::
    :hidden:
    :maxdepth: 1
-   :caption: Evaluation Suite
+   :caption: LLM Judge Suite
 
    evaluation
    llm_as_judge
    pairwise_judge
    evaluation_advanced
+
+.. toctree::
+   :hidden:
+   :maxdepth: 1
+   :caption: Utility Operators
+
+   sem_partition
+   sem_index
+   sem_dedup
+   web_search
+   web_extract
 
 .. toctree::
    :hidden:


### PR DESCRIPTION
Documentation navigation tweaks:

- **Rename** the "Evaluation Suite" sidebar section to **"LLM Judge Suite"**.
- **Move** the "Utility Operators" section **below** the LLM Judge Suite.
- **Retitle** the evaluation landing page from "Evaluation Suite" to **"Overview"**.

Sidebar order is now: … Optimizations → LLM Judge Suite → Utility Operators → Models. Sphinx build passes cleanly (no new warnings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)