### PR TITLE
Bump version to 1.2.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "lotus-ai"
-version = "1.2.3"
+version = "1.2.4"
 description = "lotus"
 readme = "README.md"
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -1366,7 +1366,7 @@ wheels = [
 
 [[package]]
 name = "lotus-ai"
-version = "1.2.3"
+version = "1.2.4"
 source = { editable = "." }
 dependencies = [
     { name = "backoff" },


### PR DESCRIPTION
Release **1.2.4** of `lotus-ai`.

- Bump `version` to `1.2.4` in `pyproject.toml`.
- Regenerate `uv.lock` to keep `uv export --locked` in sync.

On merge, a `v1.2.4` tag will trigger `publish.yml` to build and publish to PyPI.

### Since 1.2.3
- Generalized agentic operators: composable `corpus.agent(ops=[...])` (map/filter/reduce), filter as an instantiation of map, and per-op execution strategies (per_unit / batched / shared_context).
- Removed the old `agentic_map_reduce` / `agentic_map/filter/reduce` API in favor of the single `corpus.agent` surface.
- README quickstart + examples migrated; new `buggy_filter.py`; docs restructured (Agentic Semantic Operators / LLM Semantic Operators / Optimizations; new Agentic Operators, Corpus, Agentic Filter pages).

🤖 Generated with [Claude Code](https://claude.com/claude-code)