### PR TITLE
examples: summarize extracted arXiv paper with sem_agg

### DIFF
--- a/examples/web_search_examples/arxiv_extract.py
+++ b/examples/web_search_examples/arxiv_extract.py
@@ -14,3 +14,5 @@ print(f"Extracted from ArXiv:\n{df}\n\n")
 if df["full_text"].iloc[0]:
     print(f"Full text length: {len(df['full_text'].iloc[0])} characters")
     print(f"First 500 characters:\n{df['full_text'].iloc[0][:500]}...")
+    res = df.sem_agg("Summarize the paper's {full_text} in a few sentences, highlighting the main contributions and findings.")
+    print(f"\nSummary:\n{res.iloc[0]._output}")


### PR DESCRIPTION
Extend the `arxiv_extract` example to aggregate the extracted full text into a short summary of the paper's main contributions via `sem_agg`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)