### PR TITLE
perf: lazy-import litellm, faiss, torch to speed up import lotus

### DIFF
--- a/lotus/models/__init__.py
+++ b/lotus/models/__init__.py
@@ -1,10 +1,31 @@
-from lotus.models.cross_encoder_reranker import CrossEncoderReranker
 from lotus.models.lm import LM
 from lotus.models.reranker import Reranker
 from lotus.models.rm import RM
-from lotus.models.litellm_rm import LiteLLMRM
-from lotus.models.sentence_transformers_rm import SentenceTransformersRM
-from lotus.models.colbertv2_rm import ColBERTv2RM
+
+# Heavy RM/reranker backends (torch, sentence_transformers, colbert, faiss)
+# are imported lazily so `import lotus` stays fast. LM stays eager because it
+# is referenced as a type annotation across the codebase (e.g. lotus.settings).
+_LAZY = {
+    "LiteLLMRM": "lotus.models.litellm_rm",
+    "SentenceTransformersRM": "lotus.models.sentence_transformers_rm",
+    "CrossEncoderReranker": "lotus.models.cross_encoder_reranker",
+    "ColBERTv2RM": "lotus.models.colbertv2_rm",
+}
+
+
+def __getattr__(name: str):
+    if name in _LAZY:
+        import importlib
+
+        cls = getattr(importlib.import_module(_LAZY[name]), name)
+        globals()[name] = cls  # cache so subsequent access bypasses __getattr__
+        return cls
+    raise AttributeError(f"module 'lotus.models' has no attribute {name!r}")
+
+
+def __dir__() -> list[str]:
+    return sorted(list(globals()) + list(_LAZY))
+
 
 __all__ = [
     "CrossEncoderReranker",

--- a/lotus/models/lm.py
+++ b/lotus/models/lm.py
@@ -1,27 +1,14 @@
+from __future__ import annotations
+
 import hashlib
 import logging
 import math
 import time
 import warnings
 from collections import deque
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
-from litellm import batch_completion
-from litellm.exceptions import AuthenticationError
-from litellm.types.utils import ChatCompletionTokenLogprob, ChoiceLogprobs, Choices, ModelResponse
-from litellm.utils import decode, encode, token_counter
-
-# ``supports_reasoning`` moved around / was added in newer litellm. Import defensively so
-# `import lotus` never hard-fails on older litellm — fall back to the top-level symbol,
-# then to None (treated as "not a reasoning model") if unavailable.
-try:
-    from litellm.utils import supports_reasoning as _supports_reasoning
-except ImportError:  # pragma: no cover - depends on litellm version
-    try:
-        from litellm import supports_reasoning as _supports_reasoning
-    except ImportError:  # pragma: no cover
-        _supports_reasoning = None  # type: ignore[assignment]
 from openai._exceptions import OpenAIError
 from pydantic import BaseModel
 from tokenizers import Tokenizer
@@ -38,6 +25,14 @@ from lotus.types import (
     LotusUsageLimitException,
     UsageLimit,
 )
+
+if TYPE_CHECKING:
+    from litellm.types.utils import ChatCompletionTokenLogprob, ModelResponse
+
+# litellm adds ~4s to import time and is only needed when an LM is actually
+# called, not at `import lotus` time. Runtime imports of litellm are deferred
+# to the methods that use them.
+_supports_reasoning = None  # resolved lazily in is_reasoning_model()
 
 logging.getLogger("LiteLLM").setLevel(logging.CRITICAL)
 logging.getLogger("httpx").setLevel(logging.CRITICAL)
@@ -173,6 +168,8 @@ class LM:
         progress_bar_desc: str = "Processing uncached messages",
         **kwargs: dict[str, Any],
     ) -> LMOutput:
+        from litellm.types.utils import ModelResponse
+
         all_kwargs = {**self.kwargs, **kwargs}
 
         # Set top_logprobs if logprobs requested
@@ -277,6 +274,8 @@ class LM:
         Returns:
             List of ModelResponse objects from the LLM API.
         """
+        from litellm import batch_completion
+
         total_calls = len(uncached_data)
 
         pbar = tqdm(
@@ -318,6 +317,8 @@ class LM:
         Returns:
             List of ModelResponse objects from the LLM API.
         """
+        from litellm import batch_completion
+
         responses = []
         num_batches = math.ceil(len(batch) / self.max_batch_size)
         # We know rate_limit is not None because we're in the rate limiting branch
@@ -357,6 +358,8 @@ class LM:
     def _process_with_tpm_limiting(
         self, batch: list[list[dict[str, str]]], all_kwargs: dict[str, Any], pbar: tqdm
     ) -> list[ModelResponse]:
+        from litellm import batch_completion
+
         assert self.tpm_limit is not None
         responses = []
         token_estimates = []
@@ -529,6 +532,9 @@ class LM:
             self._check_usage_limit(self.stats.physical_usage, self.physical_usage_limit, "physical")
 
     def _get_top_choice(self, response: ModelResponse) -> str:
+        from litellm.exceptions import AuthenticationError
+        from litellm.types.utils import Choices
+
         # Handle authentication errors and other exceptions
         if isinstance(response, (AuthenticationError, OpenAIError)):
             raise response
@@ -557,6 +563,9 @@ class LM:
         return choice.message.content
 
     def _get_top_choice_logprobs(self, response: ModelResponse) -> list[ChatCompletionTokenLogprob]:
+        from litellm.exceptions import AuthenticationError
+        from litellm.types.utils import ChoiceLogprobs, Choices
+
         # Handle authentication errors and other exceptions
         if isinstance(response, (AuthenticationError, OpenAIError)):
             raise response
@@ -612,6 +621,8 @@ class LM:
 
     def count_tokens(self, messages: list[dict[str, str]] | str) -> int:
         """Count tokens in messages using either custom tokenizer or model's default tokenizer"""
+        from litellm.utils import token_counter
+
         if isinstance(messages, str):
             messages = [{"role": "user", "content": messages}]
 
@@ -627,6 +638,8 @@ class LM:
 
     def encode_text(self, text: str) -> list[int]:
         """Encode text into tokens using either custom tokenizer or model's default tokenizer"""
+        from litellm.utils import encode
+
         custom_tokenizer: dict[str, Any] | None = None
         if self.tokenizer:
             custom_tokenizer = dict(type="huggingface_tokenizer", tokenizer=self.tokenizer)
@@ -634,6 +647,8 @@ class LM:
 
     def decode_tokens(self, tokens: list[int]) -> str:
         """Decode tokens into text using either custom tokenizer or model's default tokenizer"""
+        from litellm.utils import decode
+
         custom_tokenizer: dict[str, Any] | None = None
         if self.tokenizer:
             custom_tokenizer = dict(type="huggingface_tokenizer", tokenizer=self.tokenizer)
@@ -679,9 +694,21 @@ class LM:
     def is_reasoning_model(self) -> bool:
         """Whether the model spends hidden reasoning tokens from the completion budget
         (e.g. gpt-5 and the o-series)."""
+        global _supports_reasoning
         if _supports_reasoning is None:
-            # litellm too old to know — assume non-reasoning (keeps the 512 default).
-            return False
+            # ``supports_reasoning`` moved around / was added in newer litellm. Import
+            # defensively so this never hard-fails on older litellm — fall back to the
+            # top-level symbol, then to None (treated as "not a reasoning model").
+            try:
+                from litellm.utils import supports_reasoning as _supports_reasoning
+            except ImportError:  # pragma: no cover - depends on litellm version
+                try:
+                    from litellm import supports_reasoning as _supports_reasoning
+                except ImportError:  # pragma: no cover
+                    _supports_reasoning = None  # type: ignore[assignment]
+            if _supports_reasoning is None:
+                # litellm too old to know — assume non-reasoning (keeps the 512 default).
+                return False
         try:
             return _supports_reasoning(model=self.model)
         except Exception:

--- a/lotus/pricing.py
+++ b/lotus/pricing.py
@@ -1,8 +1,7 @@
+from __future__ import annotations
+
 import logging
 from typing import Optional
-
-import litellm
-from litellm import completion_cost
 
 logger = logging.getLogger(__name__)
 
@@ -22,6 +21,9 @@ def calculate_cost_from_response(response) -> Optional[float]:
     Returns:
         Total cost in USD if pricing is available, None otherwise
     """
+    import litellm
+    from litellm import completion_cost
+
     try:
         return completion_cost(completion_response=response)
     except litellm.exceptions.NotFoundError as e:

--- a/lotus/types.py
+++ b/lotus/types.py
@@ -1,10 +1,14 @@
+from __future__ import annotations
+
 from dataclasses import dataclass, field
 from enum import Enum, auto
-from typing import Any, Literal
+from typing import TYPE_CHECKING, Any, Literal
 
 import pandas as pd
-from litellm.types.utils import ChatCompletionTokenLogprob
 from pydantic import BaseModel, model_validator
+
+if TYPE_CHECKING:
+    from litellm.types.utils import ChatCompletionTokenLogprob
 
 
 ################################################################################

--- a/lotus/vector_store/__init__.py
+++ b/lotus/vector_store/__init__.py
@@ -1,6 +1,26 @@
 from lotus.vector_store.vs import VS
-from lotus.vector_store.faiss_vs import FaissVS
-from lotus.vector_store.weaviate_vs import WeaviateVS
-from lotus.vector_store.qdrant_vs import QdrantVS
+
+# Concrete vector stores are imported lazily so `import lotus` does not pull in
+# faiss / weaviate / qdrant until a vector store is actually used.
+_LAZY = {
+    "FaissVS": "lotus.vector_store.faiss_vs",
+    "WeaviateVS": "lotus.vector_store.weaviate_vs",
+    "QdrantVS": "lotus.vector_store.qdrant_vs",
+}
+
+
+def __getattr__(name: str):
+    if name in _LAZY:
+        import importlib
+
+        cls = getattr(importlib.import_module(_LAZY[name]), name)
+        globals()[name] = cls  # cache so subsequent access bypasses __getattr__
+        return cls
+    raise AttributeError(f"module 'lotus.vector_store' has no attribute {name!r}")
+
+
+def __dir__() -> list[str]:
+    return sorted(list(globals()) + list(_LAZY))
+
 
 __all__ = ["VS", "FaissVS", "WeaviateVS", "QdrantVS"]

--- a/tests/test_import_lazy.py
+++ b/tests/test_import_lazy.py
@@ -1,0 +1,74 @@
+import subprocess
+import sys
+
+
+def _run(code: str) -> subprocess.CompletedProcess:
+    return subprocess.run([sys.executable, "-c", code], capture_output=True, text=True)
+
+
+def test_import_lotus_does_not_load_torch():
+    r = _run("import lotus, sys; sys.exit(0 if 'torch' not in sys.modules else 1)")
+    assert r.returncode == 0, f"torch imported eagerly:\n{r.stderr}"
+
+
+def test_import_lotus_does_not_load_sentence_transformers():
+    r = _run("import lotus, sys; sys.exit(0 if 'sentence_transformers' not in sys.modules else 1)")
+    assert r.returncode == 0, f"sentence_transformers imported eagerly:\n{r.stderr}"
+
+
+def test_import_lotus_does_not_load_faiss():
+    r = _run("import lotus, sys; sys.exit(0 if 'faiss' not in sys.modules else 1)")
+    assert r.returncode == 0, f"faiss imported eagerly:\n{r.stderr}"
+
+
+def test_lazy_imports_still_resolve():
+    r = _run(
+        "import lotus; "
+        "from lotus.models import LM, RM, Reranker, SentenceTransformersRM, "
+        "CrossEncoderReranker, LiteLLMRM, ColBERTv2RM; "
+        "from lotus.vector_store import VS, FaissVS, WeaviateVS, QdrantVS; "
+        "print('ok')"
+    )
+    assert r.returncode == 0, r.stderr
+
+
+def test_public_api_unchanged():
+    r = _run(
+        "import lotus; "
+        "assert set(lotus.models.__all__) == "
+        "{'CrossEncoderReranker','LM','RM','Reranker','LiteLLMRM',"
+        "'SentenceTransformersRM','ColBERTv2RM'}; "
+        "assert set(lotus.vector_store.__all__) == {'VS','FaissVS','WeaviateVS','QdrantVS'}; "
+        "print('ok')"
+    )
+    assert r.returncode == 0, r.stderr
+
+
+def test_lazy_attribute_cached_after_first_access():
+    r = _run(
+        "import lotus.vector_store as m; "
+        "cls = m.FaissVS; "  # triggers __getattr__ and caches in globals
+        "assert 'FaissVS' in m.__dict__, 'cache not populated'; "
+        "assert m.__dict__['FaissVS'] is cls; "
+        "print('ok')"
+    )
+    assert r.returncode == 0, r.stderr
+
+
+def test_unknown_attribute_raises_attributeerror():
+    r = _run(
+        "import lotus.models, lotus.vector_store\n"
+        "for mod in (lotus.models, lotus.vector_store):\n"
+        "    try:\n"
+        "        mod.DoesNotExist\n"
+        "        raise SystemExit('FAIL: no AttributeError')\n"
+        "    except AttributeError:\n"
+        "        pass\n"
+        "print('ok')"
+    )
+    assert r.returncode == 0, r.stderr
+
+
+def test_import_lotus_does_not_load_litellm():
+    r = _run("import lotus, sys; sys.exit(0 if 'litellm' not in sys.modules else 1)")
+    assert r.returncode == 0, f"litellm imported eagerly:\n{r.stderr}"

--- a/tests/test_lm.py
+++ b/tests/test_lm.py
@@ -236,7 +236,7 @@ class TestLM(BaseTest):
         # Create test messages
         messages = [{"role": "user", "content": f"test message {i}"} for i in range(20)]
 
-        with patch("lotus.models.lm.batch_completion") as mock_batch_completion:
+        with patch("litellm.batch_completion") as mock_batch_completion:
             # Configure mock to return responses immediately
             mock_batch_completion.return_value = [mock_response] * 10
 


### PR DESCRIPTION
## Purpose

Closes #143.

`import lotus` currently takes ~4s (per issue #143), and up to ~10s in environments where all optional backends (torch, sentence_transformers, faiss) are installed. The root cause is that `lotus/models/lm.py`, `lotus/pricing.py`, `lotus/types.py`, `lotus/models/__init__.py`, and `lotus/vector_store/__init__.py` all eagerly import heavy dependencies (`litellm` ~4s, `torch`, `sentence_transformers`, `faiss`) at `import lotus` time, even when the user never instantiates an `LM` or a vector store.

This PR defers all of those imports until they are actually needed.

## Test Plan

```bash
# 1. Verify heavy deps are no longer loaded at import time
python -c "
import lotus, sys
assert 'litellm' not in sys.modules
assert 'torch' not in sys.modules
assert 'sentence_transformers' not in sys.modules
assert 'faiss' not in sys.modules
print('lazy ok')
"

# 2. Verify import time dropped
python -c "import time; t0=time.perf_counter(); import lotus; print(f'{time.perf_counter()-t0:.3f}s')"

# 3. Verify LM still works (litellm loads lazily on first use)
python -c "
from lotus.models import LM
lm = LM(model='gpt-4o-mini')
print(lm.count_tokens('hello world'))
"

# 4. Run the new + existing tests
pytest tests/test_import_lazy.py -v
pytest tests/test_lm.py::TestLM::test_lm_rate_limiting_with_mock -v
```

## Test Results

**Import time (same environment, all backends installed):**

| | Before (main) | After (this PR) |
|---|---|---|
| `import lotus` | **10.55s** | **1.10s** (9.6x faster) |
| `litellm` loaded | yes | no (deferred) |
| `torch` loaded | yes | no (deferred) |
| `sentence_transformers` loaded | yes | no (deferred) |
| `faiss` loaded | yes | no (deferred) |

In an environment with only `litellm` installed (no torch/st/faiss, matching the issue reporter's setup), `import lotus` drops from ~4s to ~1s.

**pytest:**
- `tests/test_import_lazy.py`: **8 passed** (asserts litellm/torch/st/faiss absent from `sys.modules` after `import lotus`; verifies public API still resolves; covers `__getattr__` cache + `AttributeError` contract)
- `tests/test_lm.py::TestLM::test_lm_rate_limiting_with_mock`: **passed** (mock path updated from `lotus.models.lm.batch_completion` to `litellm.batch_completion`)
- `tests/test_lm.py`: 4 remaining failures are pre-existing and unrelated to this PR — they require `OPENAI_API_KEY` credentials (`Missing credentials` error) and fail on `main` as well.
- `ruff check` / `ruff format --check`: clean on all changed files.

## (Optional) Documentation Update

No public API changes. `from lotus.models import LM`, `from lotus.models import SentenceTransformersRM`, `from lotus.vector_store import FaissVS`, etc. all continue to work unchanged (now resolved lazily via PEP 562 `__getattr__`).

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Performance improvement
- [x] Refactoring (no functional changes)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, updating docstrings
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

<!--- pyml disable-next-line no-emphasis-as-heading -->
**BEFORE SUBMITTING, PLEASE READ <https://github.com/lotus-data/lotus/blob/main/CONTRIBUTING.md>**
